### PR TITLE
feat(i18n): Add Italian localization

### DIFF
--- a/src/assets/languages/it.json
+++ b/src/assets/languages/it.json
@@ -1,0 +1,1073 @@
+{
+  "guide": {
+    "about": {
+      "title": "Serpantinum",
+      "loading": "Caricamento...",
+      "unknown": "Sconosciuto",
+      "version_by": "v{version} • creato da {author}",
+      "hardware": {
+        "device_name": "Nome del dispositivo",
+        "processor": "Processore",
+        "graphics": "Grafica",
+        "memory": "Memoria",
+        "disk_capacity": "Capacità del disco",
+        "integrated_graphics": "Grafica integrata"
+      },
+      "system": {
+        "os_name": "Nome del sistema operativo",
+        "kernel_version": "Versione del kernel",
+        "desktop": "Desktop",
+        "shell": "Conchiglia",
+        "uptime": "Tempo di attività",
+        "default_os": "Linux"
+      },
+      "github_repo": "ilyamiro/serpantinum",
+      "default_os": "Linux"
+    },
+    "tabs": {
+      "welcome": "Benvenuto",
+      "general": "Generale",
+      "autostart": "Avvio automatico",
+      "display": "Display",
+      "bar": "Barra",
+      "launcher": "Launcher",
+      "theme": "Tema",
+      "notifications": "Notifiche",
+      "idle": "Inattività",
+      "wellbeing": "Benessere",
+      "tutorial": "Tutorial",
+      "update": "Aggiornamento",
+      "about": "Informazioni"
+    },
+    "autostart": {
+      "title": "Avvio automatico",
+      "desc": "Gestisci programmi, file binari e script avviati automaticamente all'avvio della sessione",
+      "master_switch": {
+        "title": "Abilita l'avvio automatico",
+        "desc": "Esegui globalmente l'elenco delle applicazioni di avvio configurato al momento dell'accesso"
+      },
+      "add_button": "Aggiungi applicazione",
+      "empty_title": "Nessuna applicazione con avvio automatico",
+      "empty_desc": "Fai clic su \"Aggiungi applicazione\" per specificare comandi, file binari, ritardi e numero di ripetizioni.",
+      "name_label": "Nome",
+      "name_placeholder": "per esempio. Discord, EasyEffects, Script",
+      "exec_label": "Comando eseguibile",
+      "exec_placeholder": "Percorso binario o nome con flag (ad esempio discord --start-minimized)",
+      "browse_file": "Sfoglia file",
+      "delay_label": "Ritardo di avvio",
+      "delay_desc": "Tempo in secondi da attendere prima del lancio",
+      "delay_unit": "S",
+      "count_label": "Avvia Conte",
+      "count_desc": "Numero di istanze da eseguire all'avvio",
+      "repeat_delay_label": "Ripeti intervallo",
+      "repeat_delay_desc": "Ritardo tra esecuzioni ripetute",
+      "workspace_label": "Spazio di lavoro",
+      "workspace_default": "Predefinito",
+      "silent_label": "Lancio silenzioso",
+      "silent_desc": "Non rubare la messa a fuoco quando la finestra si apre",
+      "condition_label": "Condizione di lancio",
+      "condition_always": "Sempre",
+      "condition_ac_only": "Solo alimentazione CA",
+      "condition_battery_only": "Solo batteria",
+      "condition_multi_monitor": "Solo monitor multipli",
+      "restart_crash_label": "Keep-Alive/Cane da guardia",
+      "restart_crash_desc": "Processo di respawn automatico in caso di arresto anomalo",
+      "status_running": "Corsa",
+      "status_success": "Successo",
+      "status_failed": "Fallito",
+      "status_idle": "Oziare",
+      "view_log": "Tronco d'albero",
+      "no_log": "Il registro è attualmente vuoto",
+      "run_now": "Corri adesso",
+      "delete": "Eliminare",
+      "toggle": "Abilita / Disabilita"
+    },
+    "launcher": {
+      "position": {
+        "title": "Posizione dello schermo",
+        "desc": "Seleziona a quale bordo dello schermo si collega il programma di avvio",
+        "top": "Superiore",
+        "bottom": "Metter il fondo a",
+        "left": "Sinistra",
+        "right": "Giusto"
+      },
+      "width": {
+        "title": "Larghezza del lanciatore",
+        "desc": "Larghezza totale della finestra di avvio in pixel"
+      },
+      "items": {
+        "title": "Elementi visibili",
+        "desc": "Numero di risultati di ricerca visualizzati contemporaneamente"
+      },
+      "terminal": {
+        "title": "Comando da terminale",
+        "desc": "Prefisso del comando utilizzato per > esecuzioni (ad esempio kitty -e, alacritty -e, foot -e)"
+      },
+      "smart_ranking": {
+        "title": "Ordinamento intelligente degli elementi nel launcher",
+        "desc": "Ordina le app in base all'utilizzo e alla quantità di tempo trascorso al loro interno"
+      },
+      "test": "Apri il programma di avvio"
+    },
+    "notifications": {
+      "dnd": {
+        "title": "Non disturbare",
+        "desc": "Disattiva le notifiche popup ad eccezione degli avvisi critici"
+      },
+      "position": {
+        "title": "Posizione popup",
+        "desc": "Scegli dove visualizzare i popup di notifica sullo schermo",
+        "top_right": "In alto a destra",
+        "top_left": "In alto a sinistra",
+        "bottom_right": "In basso a destra",
+        "bottom_left": "In basso a sinistra",
+        "top_center": "In alto al centro",
+        "bottom_center": "In basso al centro"
+      },
+      "sound": {
+        "title": "Suono di notifica",
+        "desc": "Riproduci un segnale audio quando arriva una notifica"
+      },
+      "sound_file": {
+        "title": "Effetto sonoro",
+        "desc": "Seleziona il suono riprodotto per gli avvisi in arrivo"
+      },
+      "empty_graphic": {
+        "title": "Animazione centro vuoto",
+        "desc": "Mostra l'animazione del gatto nel centro notifiche quando è vuoto"
+      }
+    },
+    "idle": {
+      "enabled": {
+        "title": "Abilita il sistema inattivo",
+        "desc": "Attiva la gestione dell'alimentazione e blocca i timeout"
+      },
+      "manual_inhibit": {
+        "title": "Non disturbare (rimanere sveglio)",
+        "desc": "Impedire manualmente il funzionamento al minimo del sistema"
+      },
+      "mpris_inhibit": {
+        "title": "Inibisci la riproduzione multimediale",
+        "desc": "Previeni azioni inattive durante la riproduzione dei contenuti multimediali"
+      },
+      "respect_inhibitors": {
+        "title": "Rispetta gli inibitori delle app",
+        "desc": "Honor Wayland blocca l'inibitore del minimo dalle applicazioni"
+      },
+      "pipeline_notice": "Ordine: oscuramento schermo <blocco sessione <spegnimento display <sospensione. Sono escluse le azioni che violano questo ordine.",
+      "order_violation": "Escluso",
+      "actions_header": {
+        "title": "Oggetti di timeout di inattività",
+        "desc": "Configura timeout, trigger integrati e comandi personalizzati"
+      },
+      "action_name_placeholder": "Nome dell'azione",
+      "command_placeholder": "Comando da eseguire",
+      "custom_action_default": "Azione inattiva personalizzata",
+      "custom_action_fallback": "Azione inattiva",
+      "warning_command": {
+        "title": "Comando di avviso",
+        "desc": "Offset e comando da eseguire prima dell'azione",
+        "placeholder": "per esempio. notifica-invia 'Avvertenza'"
+      },
+      "before_command": {
+        "title": "Prima del comando",
+        "desc": "Eseguito subito prima che l'azione venga attivata",
+        "placeholder": "per esempio. playerctl pausa"
+      },
+      "resume_command": {
+        "title": "Riprendi il comando",
+        "desc": "Eseguito quando riprende l'attività dell'utente",
+        "placeholder": "per esempio. notifica-invia 'Ripristinato'"
+      },
+      "dim": {
+        "title": "Schermo scuro",
+        "desc": "Tempo prima della regolazione dell'uscita"
+      },
+      "dpms": {
+        "title": "Display spento (DPMS)",
+        "desc": "Tempo prima dello spegnimento completo dello schermo"
+      },
+      "lock": {
+        "title": "Blocca la sessione",
+        "desc": "Tempo prima di richiedere la password"
+      },
+      "suspend": {
+        "title": "Sospensione del sistema",
+        "desc": "Tempo prima di mettere la macchina in stato di stop"
+      },
+      "hooks": {
+        "title": "Hook (comandi shell)"
+      }
+    },
+    "welcome": {
+      "by_author": "di @{author}",
+      "about": "Di",
+      "hold_for_tutorial": "Aspetta per il tutorial",
+      "start_tutorial": "Avvia l'esercitazione"
+    },
+    "tutorial": {
+      "section_title": "{section} tutorial",
+      "default_desc": "Fare clic per avviare il tutorial",
+      "start": "Inizio"
+    },
+    "general": {
+      "language": {
+        "title": "Lingua",
+        "desc": "Seleziona la lingua dell'interfaccia del sistema"
+      },
+      "uiscale": {
+        "title": "Scala dell'interfaccia utente",
+        "desc": "Imposta il fattore di scala generale dell'interfaccia"
+      },
+      "avatar": {
+        "title": "Immagine del profilo",
+        "desc": "Scegli l'immagine del profilo",
+        "select": "Selezionare",
+        "select_image_path": "Seleziona il percorso dell'immagine..."
+      },
+      "mutesfx": {
+        "title": "Disattiva audio audio",
+        "desc": "Disabilita gli effetti sonori dell'interfaccia utente"
+      },
+      "sfxvolume": {
+        "title": "Modifica il volume degli effetti sfx",
+        "desc": "Non influisce sulle uscite audio del sistema"
+      },
+      "quickactions": {
+        "title": "Azioni rapide",
+        "desc": "Abilita l'overlay mobile delle azioni rapide"
+      },
+      "location": {
+        "title": "Posizione",
+        "desc": "Configura la posizione per la pianificazione automatica del sole e del meteo",
+        "popup_title": "Dettagli sulla posizione",
+        "autodetect": "Rilevamento automatico",
+        "latitude": "Latitudine",
+        "longitude": "Longitudine",
+        "apply": "Fare domanda a"
+      },
+      "weatherinterval": {
+        "title": "Intervallo di polling meteorologico",
+        "desc": "Frequenza di polling in minuti"
+      },
+      "weatherunit": {
+        "title": "Unità meteorologica",
+        "desc": "Scala di temperatura per i display meteorologici",
+        "celsius": "Centigrado",
+        "fahrenheit": "Fahrenheit",
+        "kelvin": "Kelvin"
+      },
+      "copysettings": {
+        "title": "Copia impostazioni",
+        "desc": "Copia la configurazione JSON negli appunti",
+        "button": "Copia impostazioni"
+      }
+    },
+    "display": {
+      "bluelight": {
+        "title": "Filtro luce blu",
+        "desc": "Attiva/disattiva l'illuminazione calda dello schermo"
+      },
+      "enable": {
+        "title": "Abilita questo monitor",
+        "desc": "La disattivazione disattiverebbe questo monitor"
+      },
+      "schedule": {
+        "title": "Programmazione automatizzata",
+        "desc": "Regola automaticamente la temperatura del colore in base al tramonto e all'alba"
+      },
+      "temperature": {
+        "title": "Temperatura del colore",
+        "desc": "Regola l'intensità della temperatura del colore"
+      },
+      "uiscale": {
+        "title": "Scala dell'interfaccia utente",
+        "desc": "Imposta il fattore di scala del display per questo monitor"
+      },
+      "widgets": {
+        "title": "Widget del desktop",
+        "desc": "Configura e posiziona i widget per questo monitor",
+        "open": "Apri redattore"
+      }
+    },
+    "bar": {
+      "modules": {
+        "vis": "Visualizzatore (Cava)",
+        "actions": "Azioni",
+        "workspaces": "Spazi di lavoro",
+        "media": "Media",
+        "tray": "Vassoio",
+        "keyboard": "Tastiera",
+        "network": "Rete",
+        "bluetooth": "Bluetooth",
+        "volume": "Volume",
+        "battery": "Batteria",
+        "focus": "Messa a fuoco",
+        "sysmon": "Monitoraggio del sistema",
+        "timedate": "Ora/data",
+        "info": "Registrazione/Timer",
+        "weather": "Tempo atmosferico"
+      },
+      "position": {
+        "title": "Posizione della barra",
+        "desc": "Posizione della barra sullo schermo",
+        "top": "Superiore",
+        "bottom": "Metter il fondo a",
+        "left": "Sinistra",
+        "right": "Giusto"
+      },
+      "width": {
+        "title": "Larghezza della barra",
+        "desc": "Imposta la larghezza della barra come percentuale"
+      },
+      "workspaces": {
+        "title": "Scegli una quantità di aree di lavoro da visualizzare",
+        "disc": "Nota: ciò non influisce sulla quantità effettiva di spazi di lavoro nel compositore"
+      },
+      "opacity": {
+        "title": "Opacità della barra",
+        "desc": "Imposta l'opacità della barra come percentuale"
+      },
+      "style": {
+        "title": "Stile bar",
+        "desc": "Scegli tra l'aspetto modulare, solido o pieno",
+        "modular": "Modulare",
+        "solid": "Solido",
+        "fill": "Riempire"
+      },
+      "time": {
+        "title": "Formato ora",
+        "desc": "Stringa di formato (ad esempio HH:mm:ss o hh:mm AP)"
+      },
+      "guide_button": {
+        "title": "Pulsante guida",
+        "desc": "Visualizza l'attivatore popup della guida nella barra superiore"
+      },
+      "autohide": {
+        "title": "Nascondi automaticamente",
+        "desc": "Nascondi la barra quando non è sospesa"
+      },
+      "timeout": {
+        "title": "Timeout per nascondere automaticamente",
+        "desc": "Ritardo prima che la barra si nasconda"
+      },
+      "config": {
+        "title": "Configurazione della barra",
+        "desc": "Fare clic con il pulsante destro del mouse su un elemento per iniziare il raggruppamento, fare clic con il pulsante destro del mouse su un altro per aggiungerlo. Fare clic con il pulsante destro del mouse su un elemento raggruppato per rimuoverlo.",
+        "reset": "Reset",
+        "available": "Disponibile",
+        "left": "Sinistra",
+        "center": "Centro",
+        "right": "Giusto"
+      }
+    },
+    "theme": {
+      "font": {
+        "title": "Font",
+        "desc": "Scegli il valore predefinito utilizzato da Serpantinum",
+        "select": "Selezionare..."
+      },
+      "radius": {
+        "title": "Raggio del confine",
+        "desc": "Raggio dell'angolo per gli elementi dell'interfaccia utente"
+      },
+      "colors": {
+        "title": "Temi di colore",
+        "desc": "Seleziona una tavolozza di colori predefinita o crea il tuo tema personalizzato.",
+        "search": "Cerca temi..."
+      },
+      "delete_theme": "Eliminare",
+      "wallpaper": {
+        "title": "Elenco degli sfondi",
+        "desc": "Directory per la ricerca di sfondi",
+        "select_dir": "Seleziona la directory...",
+        "select_wallpaper": "Seleziona lo sfondo",
+        "no_wallpaper_selected": "Nessuno sfondo selezionato"
+      }
+    },
+    "file_picker": {
+      "title": "Scegli l'immagine",
+      "input_placeholder": "Ricerca...",
+      "not_found": "Nessun file trovato",
+      "no_file_selected": "Nessun file selezionato",
+      "root": "Radice",
+      "places": {
+        "home": "Casa",
+        "downloads": "Download",
+        "pictures": "Immagini"
+      }
+    },
+    "font_picker": {
+      "title": "Seleziona un carattere",
+      "input_placeholder": "Ricerca...",
+      "not_found": "Nessun articolo trovato",
+      "places": {
+        "user_fonts": "Caratteri utente",
+        "system_fonts": "Caratteri di sistema"
+      }
+    },
+    "sound_picker": {
+      "title": "Seleziona il suono della notifica",
+      "no_sound_selected": "Nessun suono selezionato",
+      "places": {
+        "user_sounds": "Suoni dell'utente",
+        "system_sounds": "Suoni di sistema"
+      }
+    },
+    "theme_editor": {
+      "title": "Nuovo tema colore",
+      "name_placeholder": "Nome del tema...",
+      "preview": "Anteprima",
+      "cancel": "Cancellare",
+      "save": "Salva",
+      "default_name": "Tema personalizzato",
+      "colors": {
+        "base": "Base",
+        "mantle": "Mantello",
+        "crust": "Crosta",
+        "text": "Testo",
+        "sub0": "Sotto0",
+        "sub1": "Sotto1",
+        "surf0": "Surf0",
+        "surf1": "Navigare1",
+        "surf2": "Surf2",
+        "over0": "Oltre0",
+        "over1": "Oltre1",
+        "over2": "Oltre2",
+        "blue": "Blu",
+        "lavender": "Lavanda",
+        "sapphire": "Zaffiro",
+        "sky": "Cielo",
+        "teal": "Verde acqua",
+        "green": "Verde",
+        "yellow": "Giallo",
+        "peach": "Pesca",
+        "maroon": "Marrone",
+        "red": "Rosso",
+        "mauve": "Malva",
+        "pink": "Rosa",
+        "flamingo": "Fenicottero",
+        "rosewater": "Acqua di rose"
+      }
+    },
+    "wellbeing": {
+      "desktop": "Desktop",
+      "not_available": "N / A",
+      "am": "SONO",
+      "pm": "PM",
+      "today": "Oggi",
+      "week_overview": "Panoramica della settimana",
+      "daily_average": "Media giornaliera",
+      "no_data": "Nessun dato",
+      "same_time": "Allo stesso tempo",
+      "daily_usage": "Utilizzo quotidiano",
+      "peak_hours": "Ore di punta",
+      "time_hm": "{h}h {m}m",
+      "time_m": "{m}m",
+      "months": {
+        "january": "Gennaio",
+        "february": "Febbraio",
+        "march": "Marzo",
+        "april": "aprile",
+        "may": "Maggio",
+        "june": "Giugno",
+        "july": "Luglio",
+        "august": "agosto",
+        "september": "settembre",
+        "october": "ottobre",
+        "november": "novembre",
+        "december": "Dicembre"
+      },
+      "days": {
+        "monday": "Lunedi",
+        "tuesday": "Martedì",
+        "wednesday": "Mercoledì",
+        "thursday": "Giovedì",
+        "friday": "Venerdì",
+        "saturday": "Sabato",
+        "sunday": "Domenica"
+      },
+      "settings": {
+        "title": "Impostazioni del benessere",
+        "overall_limit": "Limite giornaliero complessivo",
+        "off": "Spento",
+        "app_limits": "Limiti di utilizzo dell'app",
+        "app_limits_desc": "Imposta l'indennità giornaliera massima per richiesta",
+        "excluded_apps": "App escluse",
+        "excluded_apps_desc": "In futuro, escluderai le app dal monitoraggio generale"
+      }
+    },
+    "update_available": "Aggiornamento disponibile"
+  },
+  "sysnotif": {
+    "battery": {
+      "app_name": "Sistema",
+      "full_title": "Batteria carica",
+      "full_body": "La batteria è completamente carica (100%).",
+      "low_title": "Batteria scarica",
+      "low_body": "Il livello della batteria è al {pct}%. Collega il caricabatterie.",
+      "critical_title": "Batteria critica",
+      "critical_body": "Il livello della batteria è al {pct}%. Collega immediatamente il caricabatterie."
+    }
+  },
+  "updater": {
+    "notification": {
+      "app_name": "Aggiornamento",
+      "action_open_guide": "Apri la guida",
+      "update_available_title": "Aggiornamento disponibile: v{remote}",
+      "update_available_body": "Versione corrente: v{local}. Fare clic per visualizzare il registro delle modifiche e l'aggiornamento."
+    }
+  },
+  "polkit": {
+    "title": "Autenticazione richiesta",
+    "default_message": "Un'applicazione richiede diritti amministrativi.",
+    "default_description": "Per eseguire questa azione come superutente è necessaria l'autenticazione.",
+    "password_placeholder": "Password",
+    "error_failed": "Autenticazione non riuscita. Per favore riprova."
+  },
+  "applauncher": {
+    "search": "Ricerca",
+    "placeholder": "Inizia con > per un comando..."
+  },
+  "calendar": {
+    "loading": "Caricamento...",
+    "loading_schedule": "Caricamento programma...",
+    "no_events": "Nessun evento in programma.",
+    "open_web": "Apri rete",
+    "weather": {
+      "wind": "Vento",
+      "humid": "Umido",
+      "rain": "Piovere",
+      "feels": "Sente"
+    },
+    "days": {
+      "mo": "Mo",
+      "tu": "Tu",
+      "we": "Noi",
+      "th": "Gi",
+      "fr": "Fr",
+      "sa": "Sa",
+      "su": "Su"
+    }
+  },
+  "clipboard": {
+    "search": "Ricerca",
+    "title": "Appunti",
+    "clear": "Chiaro",
+    "empty": "Niente trovato",
+    "recent": "Recente",
+    "pinned": "Appuntato"
+  },
+  "lock": {
+    "status": {
+      "locked": "Bloccato",
+      "access_denied": "Accesso negato",
+      "authenticating": "Autenticazione...",
+      "enter_pin": "Inserisci il PIN"
+    },
+    "power": {
+      "suspend": "Sospendere",
+      "reboot": "Riavviare",
+      "power_off": "Spegnimento"
+    },
+    "default_user": "Utente",
+    "unknown": "Sconosciuto"
+  },
+  "music": {
+    "nothing_playing": "Non sta giocando niente",
+    "loading": "Caricamento...",
+    "by_artist": "Di {artist}",
+    "unknown_artist": "Artista sconosciuto",
+    "speaker": "Altoparlante",
+    "via_source": "Tramite {source}",
+    "offline": "Non in linea",
+    "equalizer": "Equalizzatore",
+    "eq": {
+      "apply": "Fare domanda a",
+      "saved": "Salvato"
+    },
+    "presets": {
+      "flat": "Piatto",
+      "bass": "Basso",
+      "treble": "Alti",
+      "vocal": "Vocale",
+      "pop": "Pop",
+      "rock": "Roccia",
+      "jazz": "Jazz",
+      "classic": "Classico",
+      "custom": "Costume"
+    }
+  },
+  "network": {
+    "tabs": {
+      "ethernet": "Ethernet",
+      "wifi": "Wifi",
+      "bluetooth": "Bluetooth"
+    },
+    "status": {
+      "no_ip": "Nessun IP",
+      "unknown": "Sconosciuto",
+      "calculating": "Calcolo...",
+      "open": "Aprire",
+      "current_device": "Dispositivo attuale",
+      "powering_on": "Accensione...",
+      "powering_off": "Spegnimento...",
+      "disconnected": "Disconnesso",
+      "disconnecting": "Disconnessione...",
+      "hold": "Presa...",
+      "connected": "Collegato"
+    },
+    "actions": {
+      "unpair": "Disaccoppia",
+      "scan": "Scansione"
+    }
+  },
+  "notifications": {
+    "center": {
+      "reserved": "Riservato per futuri aggiornamenti"
+    },
+    "types": {
+      "default": {
+        "fallback_summary": "Notifica",
+        "system": "Sistema",
+        "action": "Azione"
+      },
+      "weather": {
+        "fallback_summary": "Bollettino meteorologico",
+        "fallback_body": "Nessun dato di ripartizione fornito."
+      },
+      "screenshot": {
+        "badge": "Schermata",
+        "fallback_summary": "Schermata catturata",
+        "click_to_open": "Fare clic per aprire la cartella degli screenshot"
+      }
+    }
+  },
+  "quickactions": {
+    "systemusage": {
+      "cpu": "processore",
+      "ram": "RAM",
+      "temp": "Temp",
+      "disk": "Disco",
+      "net": "Netto"
+    },
+    "timer": {
+      "tabs": {
+        "timer": "Timer",
+        "stopwatch": "Cronometro",
+        "pomodoro": "Pomodoro"
+      },
+      "stopwatch": {
+        "lap": "Giro {number}"
+      },
+      "pomodoro": {
+        "phases": {
+          "focus": "Messa a fuoco",
+          "short_break": "Breve pausa",
+          "long_break": "Lunga pausa"
+        },
+        "settings": {
+          "work": "Lavoro (m)",
+          "short_break": "Vacanza breve (m)",
+          "long_break": "Pausa lunga (m)",
+          "sessions": "Sessioni"
+        }
+      },
+      "notification": {
+        "app_name": "Temporizzatore Quickshell",
+        "timer_finished_title": "Cronometro terminato",
+        "timer_finished_body": "Il tuo timer per {time} è stato completato.",
+        "focus_complete_title": "Messa a fuoco completata",
+        "focus_complete_body": "Ottimo lavoro! È ora di prendersi una meritata pausa.",
+        "break_over_title": "Rompere",
+        "break_over_body": "Il tempo della pausa è scaduto. Torniamo a concentrarci!",
+        "pomo_skipped_title": "Pomodoro saltò",
+        "pomo_skipped_focus_body": "Sessione di messa a fuoco saltata. Muoversi per rompere.",
+        "pomo_skipped_break_body": "Pausa saltata. Tornare a concentrarsi."
+      }
+    }
+  },
+  "screenshot": {
+    "video_mode": "Fare clic su record (il portale gestisce la selezione dell'area)",
+    "select_region": "Seleziona la regione da catturare",
+    "no_microphones": "Nessun microfono (installa Pulseaudio)",
+    "qr_timeout": "Scansione scaduta o non riuscita.",
+    "qr_not_found": "Nessun codice QR trovato.",
+    "notifications": {
+      "screenshot_app_name": "Schermata",
+      "recorder_app_name": "Registratore dello schermo",
+      "system_app_name": "Sistema di schermate",
+      "missing_deps_title": "Dipendenze mancanti",
+      "missing_deps_body": "Impossibile avviare. Si prega di installare:\n{cmds}",
+      "open_folder": "Apri cartella",
+      "recording_saved_title": "Registrazione salvata",
+      "recording_saved_body": "File: {file}\nCartella: {folder}",
+      "recording_error_title": "Errore",
+      "recording_error_body": "Impossibile salvare il file video.",
+      "recording_started_title": "La registrazione è iniziata",
+      "recording_started_body": "Premi di nuovo la scorciatoia dello screenshot per interrompere.",
+      "screenshot_saved_title": "Schermata salvata",
+      "screenshot_saved_body": "File: {file}\nCartella: {folder}"
+    }
+  },
+  "start": {
+    "title": "Serpantino",
+    "made_by": "Realizzato da @{author}",
+    "welcome": "Benvenuto",
+    "tagline": "Una shell desktop creata per",
+    "you": "Voi",
+    "start_preview": "Avvia l'anteprima"
+  },
+  "syspanel": {
+    "user": {
+      "default_name": "Utente",
+      "default_os": "Linux",
+      "logout": "Esci"
+    },
+    "notifications": {
+      "title": "Notifiche",
+      "clear": "Chiaro",
+      "silent": "Silenzioso",
+      "mute": "Muto",
+      "empty": "Sei tutto preso."
+    },
+    "profiles": {
+      "performance": "Prestazione",
+      "balanced": "Equilibrato",
+      "power_saver": "Risparmio energetico"
+    },
+    "battery": {
+      "fully_charged": "Completamente carico",
+      "charging": "In carica",
+      "charging_time": "Ricarica • {hours}h {mins}m",
+      "discharging": "Scarica",
+      "left_time": "{hours}h {mins}m a sinistra",
+      "until_full": "fino al pieno",
+      "remaining": "rimanente"
+    },
+    "actions": {
+      "system_name": "Sistema",
+      "hibernate_error_title": "Ibernazione non disponibile",
+      "hibernate_error_body": "L'ibernazione non è disponibile su questo sistema. Controlla la configurazione dello scambio."
+    }
+  },
+  "volumepopup": {
+    "no_device": "Nessun dispositivo",
+    "mute": "Muto",
+    "master_output_volume": "Volume di uscita principale",
+    "no_active_streams": "Nessun flusso attivo",
+    "active_default": "Predefinito attivo",
+    "tabs": {
+      "outputs": "Uscite",
+      "inputs": "Ingressi",
+      "streams": "Flussi"
+    }
+  },
+  "wallpaper": {
+    "notifications": {
+      "downloading": "Download dello sfondo in corso...",
+      "type_to_search": "Digita qualcosa da cercare...",
+      "search_paused": "Ricerca sospesa",
+      "searching_ddg": "Ricerca di sfondi...",
+      "generating_thumbnails": "Generazione delle miniature in corso...",
+      "no_wallpapers_found": "Nessuno sfondo trovato",
+      "videos": "Video",
+      "history": "Applicato di recente"
+    },
+    "filters": {
+      "all": "Tutto",
+      "vid": "Video",
+      "search": "Ricerca",
+      "red": "Rosso",
+      "orange": "Arancia",
+      "yellow": "Giallo",
+      "green": "Verde",
+      "blue": "Blu",
+      "purple": "Viola",
+      "pink": "Rosa",
+      "monochrome": "Monocromo"
+    }
+  },
+  "weather": {
+    "desc": {
+      "sunny": "Soleggiato",
+      "clear": "Chiaro",
+      "cloudy": "Nuvoloso",
+      "mist": "Nebbia",
+      "rainy": "Piovoso",
+      "snow": "Nevicare",
+      "storm": "Tempesta",
+      "unknown": "Sconosciuto",
+      "offline": "Non in linea"
+    },
+    "days": {
+      "mon": "Lun",
+      "tue": "Mar",
+      "wed": "Mercoledì",
+      "thu": "Gio",
+      "fri": "Ven",
+      "sat": "Sab",
+      "sun": "Sole",
+      "monday": "Lunedi",
+      "tuesday": "Martedì",
+      "wednesday": "Mercoledì",
+      "thursday": "Giovedì",
+      "friday": "Venerdì",
+      "saturday": "Sabato",
+      "sunday": "Domenica"
+    },
+    "months": {
+      "jan": "Gen",
+      "feb": "Febbraio",
+      "mar": "Mar",
+      "apr": "aprile",
+      "may": "Maggio",
+      "jun": "giugno",
+      "jul": "Lug",
+      "aug": "Agosto",
+      "sep": "Settembre",
+      "oct": "ottobre",
+      "nov": "novembre",
+      "dec": "dicembre"
+    }
+  },
+  "widgets": {
+    "wallpaper": {
+      "name": "Selettore di sfondi",
+      "desc": "Sfoglia e imposta lo sfondo del desktop"
+    },
+    "network": {
+      "name": "Impostazioni di rete",
+      "desc": "Gestisci WiFi, Ethernet e connessioni di rete"
+    },
+    "volume": {
+      "name": "Volume e audio",
+      "desc": "Gestisci i dispositivi audio e i livelli di volume"
+    },
+    "guide": {
+      "name": "Impostazioni",
+      "desc": "Configurazione e impostazioni di Serpantinum"
+    },
+    "calendar": {
+      "name": "Calendario e orologio",
+      "desc": "Visualizza data, ora e programma"
+    },
+    "music": {
+      "name": "Lettore multimediale",
+      "desc": "Controlla la riproduzione di musica e contenuti multimediali"
+    },
+    "notifications": {
+      "name": "Centro notifiche",
+      "desc": "Visualizza le notifiche e la cronologia recenti"
+    },
+    "system": {
+      "name": "Controlli di sistema",
+      "desc": "Monitoraggio delle prestazioni, alimentazione e impostazioni rapide"
+    },
+    "translator": {
+      "name": "Traduttore",
+      "desc": "Traduttore istantaneo di testo e selezione"
+    },
+    "redactor": {
+      "no_widgets_active": "Nessun widget attivo",
+      "click_to_add": "Fare clic sull'icona di un widget nella barra degli strumenti in basso per aggiungerlo",
+      "done": "Fatto"
+    },
+    "types": {
+      "clock": "Orologio",
+      "music": "Musica",
+      "weather": "Meteo",
+      "image": "Immagine"
+    },
+    "variants": {
+      "digital": "Digitale",
+      "analog": "Analogico",
+      "full": "Completo",
+      "minimal": "Minimo",
+      "round": "Rotondo",
+      "compact": "Compatto",
+      "rect": "Rettangolare",
+      "rounded": "Arrotondato"
+    }
+  },
+  "cli": {
+    "usage": "Utilizzo: serpantino [comando] [opzioni...]",
+    "description": "Una shell desktop per i compositori Wayland.",
+    "commands": "Comandi:",
+    "script_commands": "Comandi di script:",
+    "launch_desc": "Avvia componenti autonomi (start, widgetredactor)",
+    "msg_desc": "Invia comandi o passaggi dell'area di lavoro al gestore dell'interfaccia utente",
+    "ipc_desc": "Inoltra le chiamate IPC direttamente alla shell",
+    "kill_desc": "Interrompere in modo pulito il demone in esecuzione",
+    "options": "Opzioni:",
+    "verbose_desc": "Abilita l'output di registrazione dettagliato",
+    "version_desc": "Visualizza le informazioni sulla versione ed esce",
+    "help_desc": "Mostra questo messaggio di aiuto ed esci",
+    "examples": "Esempi:",
+    "daemon_stopped": "Il demone Serpantinum si fermò.",
+    "starting_daemon": "Il demone non è in esecuzione. Avvio serpantinumd in background...",
+    "error_missing_qml": "Errore: target mancante da avviare.",
+    "launch_usage": "Utilizzo: serpantino launch <start|widgetredactor> [args...]",
+    "error_qml_not_found": "Errore: impossibile risolvere {NAME}.qml in {DIR}",
+    "error_shell_qml_not_found": "Errore: impossibile risolvere il percorso di shell.qml in {DIR}",
+    "error_unknown_command": "Errore: comando sconosciuto '{CMD}'.",
+    "error_unknown_target": "Errore: destinazione sconosciuta '{TARGET}'.",
+    "launch_help": {
+      "usage": "Utilizzo: serpantino launch <start|widgetredactor> [argomenti...]",
+      "description": "Avvia componenti autonomi direttamente in modalità runner.",
+      "available_targets": "Obiettivi disponibili:",
+      "target_start": "Avvia l'interfaccia di configurazione iniziale",
+      "target_widgetredactor": "Avvia l'interfaccia dell'editor dei widget sul desktop"
+    },
+    "msg_help": {
+      "usage": "Utilizzo: serpantinum msg <comando|area di lavoro> [argomenti...]",
+      "description": "Invia direttamente messaggi di layout, area di lavoro e gestione delle finestre.",
+      "available_commands": "Messaggi disponibili:",
+      "cmd_workspace": "Passa all'area di lavoro <num> (aggiungi 'sposta' per inviare la finestra attiva)",
+      "cmd_open": "Apri un pannello dell'interfaccia utente gestita (rete, guida, sfondo, applauncher)",
+      "cmd_toggle": "Attiva/disattiva un pannello dell'interfaccia utente gestito",
+      "cmd_close": "Chiudi qualsiasi overlay di shell attivo"
+    },
+    "ipc_help": {
+      "usage": "Utilizzo: serpantinum ipc call <target> <metodo> [argomenti...]",
+      "description": "Invia una chiamata IPC direttamente all'istanza QuickShell in esecuzione."
+    },
+    "scripts": {
+      "exit": "Termina la sessione grafica ed esci dal compositore",
+      "lock": "Attiva l'interfaccia della schermata di blocco",
+      "volume": "Controlla il volume del sink/sorgente audio predefinito e gli stati di disattivazione dell'audio",
+      "reload": "Forza il ricaricamento degli elementi del desktop QuickShell",
+      "weather": "Recupera e gestisci i dati e le cache delle previsioni del tempo",
+      "location": "Recupera e aggiorna le coordinate geografiche",
+      "screenshot": "Cattura immagini dello schermo, registra video o analizza i codici QR",
+      "brightness": "Regola la luminosità del display retroilluminato",
+      "current_focus": "Monitorare e registrare le modifiche del focus della finestra attiva",
+      "monitors_detect": "Interroga gli output di visualizzazione attivi e le frequenze di aggiornamento",
+      "location_manual": "Imposta manualmente le coordinate geografiche e il fuso orario",
+      "blue_light_filter": "Regola la temperatura del colore e la programmazione automatica giorno/notte",
+      "autostart": "Esegui applicazioni e servizi con avvio automatico configurati dall'utente",
+      "translate": "Traduttore istantaneo di testo e selezione"
+    }
+  },
+  "daemon": {
+    "already_running": "Il demone è già in esecuzione. Uscendo...",
+    "shutting_down": "Spegnimento del demone serpantino...",
+    "launching": "Avvio del demone serpantino...",
+    "cli": {
+      "usage": "Utilizzo: serpantinumd <comando> [opzioni...]",
+      "description": "Demone del servizio in background per la shell desktop Serpantinum.",
+      "commands": "Comandi:",
+      "cmd_start": "Avvia il servizio demone e avvia i lavoratori in background",
+      "cmd_stop": "Interrompere il servizio demone in esecuzione",
+      "cmd_status": "Controlla lo stato di esecuzione del servizio demone",
+      "options": "Opzioni:",
+      "opt_verbose": "Abilita la registrazione dettagliata dell'output",
+      "opt_version": "Mostra le informazioni sulla versione ed esce",
+      "opt_help": "Mostra questo messaggio di aiuto ed esci",
+      "stopped": "Il demone Serpantinum si fermò.",
+      "status_running": "Il demone Serpantinum è in esecuzione (PID: {PID}).",
+      "status_stopped": "Il demone Serpantinum non è in esecuzione.",
+      "unknown_arg": "Argomento sconosciuto: {ARG}"
+    }
+  },
+  "installer": {
+    "auth": {
+      "enter_code": "Inserisci il codice di accesso all'installazione:",
+      "error_interactive": "Errore: terminale interattivo richiesto per l'autenticazione.",
+      "error_empty": "Autenticazione non riuscita: il codice di accesso non può essere vuoto.",
+      "error_default": "Autenticazione non riuscita: codice di accesso non valido o esaurito.",
+      "error_failed": "Autenticazione non riuscita.",
+      "access_granted": "Accesso concesso. (gli utenti{active}/{max} hanno attivato questo codice)"
+    },
+    "os": {
+      "error_root": "Errore: non eseguire questo script direttamente con root/sudo. Esegui come utente normale.",
+      "error_unsupported": "Sistema operativo non supportato ({os}). Serpantinum supporta rigorosamente Arch Linux e derivati.",
+      "error_not_found": "Impossibile rilevare il sistema operativo. /etc/os-release non trovato.",
+      "unknown_cpu": "CPU sconosciuta",
+      "unknown_gpu": "Macchina sconosciuta/virtuale",
+      "default_os": "ArcoLinux"
+    },
+    "ui": {
+      "user": "Utente:",
+      "os": "Sistema operativo:",
+      "cpu": "PROCESSORE:",
+      "gpu": "GPU:",
+      "target_version": "Versione di destinazione:",
+      "install_mode": "Modalità di installazione:",
+      "github": "GitHub:",
+      "twitter": "Twitter:",
+      "reddit": "Reddit:",
+      "telegram": "Telegramma:",
+      "donate": "Donare:",
+      "donate_sub": "(Sostieni il progetto!)",
+      "packages_prompt": "Pacchetti >",
+      "packages_header": "Premi Esc o Invio per tornare",
+      "package_missing": "{pkg} (mancante - verrà installato)",
+      "package_installed": "{pkg} (installato)",
+      "compositors_title": "=== Seleziona i compositori di destinazione ===",
+      "installed": "(installato)",
+      "not_installed": "(non installato)",
+      "done": "Fatto",
+      "compositors_prompt": "Configurazione del compositore >",
+      "compositors_header": "Attiva/disattiva i compositori supportati, quindi seleziona Fine",
+      "sddm_title": "=== Configurazione del Display Manager (SDDM) ===",
+      "sddm_detected_active": "Rilevato display manager attivo/abilitato: {dm}",
+      "sddm_detected_none": "Rilevato display manager attivo/abilitato: nessuno",
+      "sddm_opt_install": "Installa e configura SDDM (tema Material You)",
+      "sddm_opt_disable": "Disabilita e rimuovi '{dm}'",
+      "sddm_opt_wayland": "Backend Force Wayland",
+      "sddm_prompt": "Configurazione SDDM >",
+      "sddm_header": "Attiva/disattiva le opzioni, quindi seleziona Fine",
+      "target_compositor_none": "Compositore di destinazione [richiesto - nessuno selezionato]",
+      "target_compositor_selected": "Compositore di destinazione [{comps}]",
+      "target_compositor_req": "Compositore di destinazione ({label}) [Obbligatorio]",
+      "target_compositor_label": "Compositore di destinazione ({comps})",
+      "unsupported_compositor": "Compositore non supportato",
+      "menu_overview": "Panoramica sull'installazione del pacchetto ({count} pacchetti principali)",
+      "menu_sddm": "Gestore accessi SDDM",
+      "menu_wallpapers": "Pacchetto di sfondi",
+      "menu_telemetry": "Telemetria anonima",
+      "menu_update": "Aggiornamento",
+      "menu_reinstall": "Reinstallare",
+      "menu_install": "Installare",
+      "menu_exit": "Uscita",
+      "main_menu_prompt": "Menù principale >",
+      "main_menu_header": "Utilizzare i tasti freccia per navigare, Invio per selezionare",
+      "error_no_compositor": "Devi scegliere almeno un compositore supportato prima di procedere.",
+      "tagline": "Una shell desktop creata per te",
+      "support_creator": "Sostieni il creatore:",
+      "buy_coffee": "Se ti piace questo progetto, considera di offrirmi un caffè!",
+      "installed_success": "✔ Serpantino {ver} ({commit}) installato correttamente.",
+      "failed_packages": "I seguenti pacchetti hanno riscontrato errori durante l'installazione:",
+      "restart_prompt": "Riavvia il compositore o esegui \"serpantinumd start\" per iniziare.",
+      "ask_reboot": "Vuoi ricominciare? [sì/no]"
+    },
+    "deps": {
+      "syncing": "Sincronizzazione e aggiornamento dei pacchetti di sistema (pacman -Syyu)...",
+      "all_installed": "-> Tutti i pacchetti sono già installati! Saltare la fase di download del pacchetto.",
+      "missing_count": "-> Trovato {count} pacchetti mancanti da installare.",
+      "installing_title": "Installazione dei pacchetti di sistema e delle dipendenze...",
+      "installing_pkg": "Installazione {pkg}...",
+      "install_ok": "{pkg} installato con successo",
+      "install_failed": "Impossibile installare {pkg}"
+    },
+    "deploy": {
+      "configuring_sddm": "Configurazione del display manager SDDM in corso...",
+      "disabling_dm": "-> Disattivazione del display manager in conflitto: {dm}",
+      "sddm_success": "-> Materiale SDDM Tema installato, servizio abilitato [OK]"
+    }
+  },
+  "translator": {
+    "title": "Traduttore",
+    "status_translating": "Traduzione...",
+    "speed": "Velocità:",
+    "detected": "Rilevato:",
+    "input_label": "Testo di origine",
+    "placeholder": "Digita, incolla o pronuncia il testo qui...",
+    "chars": "caratteri",
+    "translation_label": "Traduzione",
+    "empty_prompt": "La traduzione apparirà qui immediatamente...",
+    "recent": "Recente:",
+    "failed": "Nessuna traduzione disponibile"
+  }
+}

--- a/src/quickshell/guide/general/GeneralTab.qml
+++ b/src/quickshell/guide/general/GeneralTab.qml
@@ -72,8 +72,8 @@ Item {
         return path;
     }
 
-    property var languageCodes: ["en", "ru", "de", "es"]
-    property var languageNames: ["English", "Русский", "Deutsch", "Español"]
+    property var languageCodes: ["en", "ru", "de", "es", "it"]
+    property var languageNames: ["English", "Русский", "Deutsch", "Español", "Italiano"]
 
     property var weatherUnitCodes: ["metric", "imperial", "standard"]
     property var weatherUnitNames: ["Celsius", "Fahrenheit", "Kelvin"]


### PR DESCRIPTION
This PR adds full Italian localization to serpantinum:

### Changes:
- `src/assets/languages/it.json`: Complete Italian localization covering widgets, guide tabs, system popups, and shell modules.
- `src/quickshell/guide/general/GeneralTab.qml`: Added Italian (`Italiano`) to language selection settings.

Part of #164.