### PR TITLE
Add DDC brightness fallback for external monitors

### DIFF
--- a/install/modules/deps.sh
+++ b/install/modules/deps.sh
@@ -48,7 +48,7 @@ SUPPORTED_DISTROS=(
 REQUIRED_PKGS=(
     "kitty" "cava" "zbar" "pavucontrol" "alsa-utils"
     "wl-clipboard" "fd" "qt6-multimedia" "qt6-5compat" "ripgrep"
-    "cliphist" "jq" "socat" "inotify-tools" "pamixer" "brightnessctl" "acpi" "iw"
+    "cliphist" "jq" "socat" "inotify-tools" "pamixer" "brightnessctl" "ddcutil" "acpi" "iw"
     "bluez" "bluez-utils" "libnotify" "networkmanager" "lm_sensors" "bc" "matugen"
     "pipewire" "wireplumber" "pipewire-pulse" "pipewire-alsa" "libpulse" "python"
     "imagemagick" "wget" "file" "git" "psmisc"

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -13,6 +13,7 @@ in
   config = mkIf cfg.enable {
     networking.networkmanager.enable = mkDefault true;
     hardware.bluetooth.enable = mkDefault true;
+    hardware.i2c.enable = mkDefault true;
     services.power-profiles-daemon.enable = mkDefault true;
     security.rtkit.enable = mkDefault true;
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -10,6 +10,7 @@
 , bc
 , bluez
 , brightnessctl
+, ddcutil
 , cava
 , cliphist
 , easyeffects
@@ -39,6 +40,7 @@
 , satty
 , slurp
 , socat
+, util-linux
 , wf-recorder
 , wget
 , wireplumber
@@ -62,6 +64,7 @@ let
     bc
     bluez
     brightnessctl
+    ddcutil
     cava
     cliphist
     easyeffects
@@ -92,6 +95,7 @@ let
     satty
     slurp
     socat
+    util-linux
     wf-recorder
     wget
     wireplumber

--- a/src/quickshell/popouts/Osd.qml
+++ b/src/quickshell/popouts/Osd.qml
@@ -140,18 +140,26 @@ PanelWindow {
         property int targetPct: -1
         onTriggered: {
             if (targetPct >= 0) {
-                if (osdWindow.kind === "volume") {
-                    if (targetPct > 0 && osdWindow.isMuted) {
-                        if (Audio.defaultSink && Audio.defaultSink.audio && Audio.defaultSink.audio.muted) {
-                            Audio.toggleMute(Audio.defaultSink);
-                        }
+                if (targetPct > 0 && osdWindow.isMuted) {
+                    if (Audio.defaultSink && Audio.defaultSink.audio && Audio.defaultSink.audio.muted) {
+                        Audio.toggleMute(Audio.defaultSink);
                     }
-                    if (Audio.defaultSink) {
-                        Audio.setVolume(Audio.defaultSink, targetPct);
-                    }
-                } else {
-                    Quickshell.execDetached(["brightnessctl", "set", targetPct + "%"]);
                 }
+                if (Audio.defaultSink) {
+                    Audio.setVolume(Audio.defaultSink, targetPct);
+                }
+                targetPct = -1;
+            }
+        }
+    }
+
+    Timer {
+        id: briCmdThrottle
+        interval: 400
+        property int targetPct: -1
+        onTriggered: {
+            if (targetPct >= 0) {
+                Quickshell.execDetached(["bash", Caching.qsDir + "/../scripts/brightness.sh", "set", targetPct.toString()]);
                 targetPct = -1;
             }
         }
@@ -535,9 +543,11 @@ PanelWindow {
                                 Audio.toggleMute(Audio.defaultSink);
                             }
                         } else {
+                            briCmdThrottle.stop();
+                            briCmdThrottle.targetPct = -1;
                             let target = osdWindow.briVal > 0 ? 0 : 100;
                             OsdController.briVal = target;
-                            Quickshell.execDetached(["brightnessctl", "set", target + "%"]);
+                            Quickshell.execDetached(["bash", Caching.qsDir + "/../scripts/brightness.sh", "set", target.toString()]);
                         }
                     }
                 }
@@ -568,15 +578,27 @@ PanelWindow {
                     handleBorderColor: Qt.rgba(0, 0, 0, 0.2)
 
                     onDragStarted: OsdController.cancelHide()
-                    onDragFinished: OsdController.restartTimer()
+                    onDragFinished: {
+                        OsdController.restartTimer();
+                        if (osdWindow.kind !== "volume" && briCmdThrottle.targetPct >= 0) {
+                            briCmdThrottle.stop();
+                            Quickshell.execDetached(["bash", Caching.qsDir + "/../scripts/brightness.sh", "set", briCmdThrottle.targetPct.toString()]);
+                            briCmdThrottle.targetPct = -1;
+                        }
+                    }
                     onMoved: val => {
                         OsdController.restartTimer();
                         let pct = Math.max(0, Math.min(100, Math.round(val)));
                         if (osdWindow.kind !== "volume") {
                             OsdController.briVal = pct;
                         }
-                        cmdThrottle.targetPct = pct;
-                        if (!cmdThrottle.running) cmdThrottle.start();
+                        if (osdWindow.kind === "volume") {
+                            cmdThrottle.targetPct = pct;
+                            if (!cmdThrottle.running) cmdThrottle.start();
+                        } else {
+                            briCmdThrottle.targetPct = pct;
+                            if (!verticalSlider.isDragging) briCmdThrottle.restart();
+                        }
                     }
                 }
             }
@@ -620,15 +642,18 @@ PanelWindow {
                                     Audio.toggleMute(Audio.defaultSink);
                                 }
                             } else {
+                                briCmdThrottle.stop();
+                                briCmdThrottle.targetPct = -1;
                                 let target = osdWindow.briVal > 0 ? 0 : 100;
                                 OsdController.briVal = target;
-                                Quickshell.execDetached(["brightnessctl", "set", target + "%"]);
+                                Quickshell.execDetached(["bash", Caching.qsDir + "/../scripts/brightness.sh", "set", target.toString()]);
                             }
                         }
                     }
                 }
 
                 Draggable {
+                    id: horizontalSlider
                     width: Math.max(0, osdContainer.width - osdWindow.s(80))
                     height: osdWindow.s(18)
                     anchors.left: parent.left
@@ -657,15 +682,27 @@ PanelWindow {
                     handleBorderColor: Qt.rgba(0, 0, 0, 0.2)
 
                     onDragStarted: OsdController.cancelHide()
-                    onDragFinished: OsdController.restartTimer()
+                    onDragFinished: {
+                        OsdController.restartTimer();
+                        if (osdWindow.kind !== "volume" && briCmdThrottle.targetPct >= 0) {
+                            briCmdThrottle.stop();
+                            Quickshell.execDetached(["bash", Caching.qsDir + "/../scripts/brightness.sh", "set", briCmdThrottle.targetPct.toString()]);
+                            briCmdThrottle.targetPct = -1;
+                        }
+                    }
                     onMoved: val => {
                         OsdController.restartTimer();
                         let pct = Math.max(0, Math.min(100, Math.round(val)));
                         if (osdWindow.kind !== "volume") {
                             OsdController.briVal = pct;
                         }
-                        cmdThrottle.targetPct = pct;
-                        if (!cmdThrottle.running) cmdThrottle.start();
+                        if (osdWindow.kind === "volume") {
+                            cmdThrottle.targetPct = pct;
+                            if (!cmdThrottle.running) cmdThrottle.start();
+                        } else {
+                            briCmdThrottle.targetPct = pct;
+                            if (!horizontalSlider.isDragging) briCmdThrottle.restart();
+                        }
                     }
                 }
             }

--- a/src/quickshell/singletons/widgetcontrols/OsdController.qml
+++ b/src/quickshell/singletons/widgetcontrols/OsdController.qml
@@ -23,6 +23,7 @@ Item {
     property real lastVolume: -1
     property bool lastMuted: false
     property int lastBrightness: -1
+    property bool brightnessInitialized: false
     property bool isInitialized: false
 
     Timer {
@@ -76,7 +77,7 @@ Item {
     Process {
         id: briWatcher
         running: true
-        command: ["sh", "-c", "inotifywait -m -e modify /sys/class/backlight/*/brightness 2>/dev/null"]
+        command: ["bash", Caching.qsDir + "/../scripts/brightness.sh", "watch"]
         stdout: SplitParser {
             onRead: data => {
                 briFetchDebounce.restart();
@@ -97,13 +98,17 @@ Item {
     Process {
         id: briFetcher
         running: true
-        command: ["bash", "-c", "brightnessctl -m 2>/dev/null | awk -F, '{print substr($4, 1, length($4)-1)}'"]
+        command: ["bash", Caching.qsDir + "/../scripts/brightness.sh", "get"]
         stdout: StdioCollector {
             onStreamFinished: {
                 let out = this.text.trim();
                 if (out !== "") {
                     let val = parseInt(out);
                     if (!isNaN(val)) {
+                        if (!controller.brightnessInitialized) {
+                            controller.lastBrightness = val;
+                            controller.brightnessInitialized = true;
+                        }
                         controller.sysBrightness = val;
                         controller.briVal = val;
                     }

--- a/src/quickshell/syspanel/SystemPanel.qml
+++ b/src/quickshell/syspanel/SystemPanel.qml
@@ -89,6 +89,7 @@ Item {
 
     property bool isDraggingVol: false
     property bool isDraggingBri: false
+    property bool usesDdcBrightness: false
 
     property bool btStateBeforeAirplane: false
     property bool wifiStateBeforeAirplane: true
@@ -226,7 +227,7 @@ Item {
 
     Timer {
         id: briPollerTimer
-        interval: 1500
+        interval: root.usesDdcBrightness ? 10000 : 1500
         repeat: false
         onTriggered: {
             if (root.visible) briPoller.running = true;
@@ -234,8 +235,17 @@ Item {
     }
 
     Process {
+        id: briBackend
+        command: ["bash", Caching.qsDir + "/../scripts/brightness.sh", "backend"]
+        running: true
+        stdout: StdioCollector {
+            onStreamFinished: root.usesDdcBrightness = this.text.trim() === "ddc"
+        }
+    }
+
+    Process {
         id: briPoller
-        command: ["bash", "-c", "brightnessctl -m 2>/dev/null | awk -F, '{print substr($4, 1, length($4)-1)}'"]
+        command: ["bash", Caching.qsDir + "/../scripts/brightness.sh", "get"]
         running: false
         stdout: StdioCollector {
             onStreamFinished: {
@@ -641,19 +651,21 @@ Item {
                                 accentColor: ThemeBackend.surface1
                                 textColor: isHoveredOrHighlighted ? ThemeBackend.text : root.briColor
                                 onClicked: {
+                                    briCmdThrottle.stop();
+                                    briCmdThrottle.targetPct = -1;
                                     let target = root.sysBrightness > 0 ? 0 : 100;
                                     root.sysBrightness = target;
-                                    Quickshell.execDetached(["brightnessctl", "set", target + "%"]);
+                                    Quickshell.execDetached(["bash", Caching.qsDir + "/../scripts/brightness.sh", "set", target.toString()]);
                                 }
                             }
 
                             Timer {
                                 id: briCmdThrottle
-                                interval: 50
+                                interval: 400
                                 property int targetPct: -1
                                 onTriggered: {
                                     if (targetPct >= 0) {
-                                        Quickshell.execDetached(["brightnessctl", "set", targetPct + "%"]);
+                                        Quickshell.execDetached(["bash", Caching.qsDir + "/../scripts/brightness.sh", "set", targetPct.toString()]);
                                         targetPct = -1;
                                     }
                                 }
@@ -687,9 +699,9 @@ Item {
                                     root.isDraggingBri = true;
                                 }
                                 onDragFinished: {
-                                    if (briCmdThrottle.running && briCmdThrottle.targetPct >= 0) {
+                                    if (briCmdThrottle.targetPct >= 0) {
                                         briCmdThrottle.stop();
-                                        Quickshell.execDetached(["brightnessctl", "set", briCmdThrottle.targetPct + "%"]);
+                                        Quickshell.execDetached(["bash", Caching.qsDir + "/../scripts/brightness.sh", "set", briCmdThrottle.targetPct.toString()]);
                                         briCmdThrottle.targetPct = -1;
                                     }
                                     briSyncDelay.restart();
@@ -699,7 +711,7 @@ Item {
                                     root.sysBrightness = pct;
                                     briSlider.value = pct;
                                     briCmdThrottle.targetPct = pct;
-                                    if (!briCmdThrottle.running) briCmdThrottle.start();
+                                    if (!briSlider.isDragging) briCmdThrottle.restart();
                                 }
                             }
                         }

--- a/src/scripts/brightness.sh
+++ b/src/scripts/brightness.sh
@@ -2,13 +2,187 @@
 
 source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/caching.sh"
 
-ACTION=$1
+[[ ${1:-} == "--verbose" ]] && shift
+ACTION=${1:-get}
+VALUE=${2:-}
+DDC_CACHE="$QS_RUN_DIR/brightness-ddc"
+DDC_LOCK="$QS_RUN_DIR/brightness-ddc.lock"
+BRIGHTNESS_STATE="$QS_RUN_DIR/brightness"
 
-case $ACTION in
+has_backlight() {
+    [[ -n "$(brightnessctl --class=backlight -m 2>/dev/null)" ]]
+}
+
+detect_ddc_bus() {
+    local bus
+
+    if [[ -f "$DDC_CACHE" ]] && read -r bus _ < "$DDC_CACHE" && [[ -c "/dev/i2c-$bus" ]]; then
+        printf '%s\n' "$bus"
+        return 0
+    fi
+
+    command -v ddcutil >/dev/null 2>&1 || return 1
+    bus=$(timeout 5s ddcutil detect --brief 2>/dev/null | awk '/I2C bus:/ { sub(".*/i2c-", "", $3); print $3; exit }')
+    [[ "$bus" =~ ^[0-9]+$ ]] || return 1
+    printf '%s\n' "$bus" > "$DDC_CACHE"
+    printf '%s\n' "$bus"
+}
+
+ddc_get_locked() {
+    local attempt bus output current maximum
+
+    for attempt in 1 2; do
+        bus=$(detect_ddc_bus) || return 1
+        output=$(timeout 5s ddcutil --bus "$bus" --brief getvcp 10 2>/dev/null) || {
+            rm -f "$DDC_CACHE"
+            continue
+        }
+        read -r _ _ _ current maximum <<< "$output"
+        [[ "$current" =~ ^[0-9]+$ && "$maximum" =~ ^[0-9]+$ && "$maximum" -gt 0 ]] || return 1
+        printf '%s %s\n' "$bus" "$maximum" > "$DDC_CACHE"
+        printf '%d\n' "$((current * 100 / maximum))"
+        return 0
+    done
+
+    return 1
+}
+
+ddc_get() {
+    exec 9>"$DDC_LOCK"
+    flock 9 || return 1
+    ddc_get_locked
+}
+
+ddc_set_locked() {
+    local percent=$1
+    local attempt bus output current maximum raw
+
+    for attempt in 1 2; do
+        bus=
+        maximum=
+        if [[ -f "$DDC_CACHE" ]]; then
+            read -r bus maximum < "$DDC_CACHE"
+        fi
+        if [[ ! "$bus" =~ ^[0-9]+$ || ! "$maximum" =~ ^[0-9]+$ || "$maximum" -le 0 ]]; then
+            bus=$(detect_ddc_bus) || return 1
+            output=$(timeout 5s ddcutil --bus "$bus" --brief getvcp 10 2>/dev/null) || {
+                rm -f "$DDC_CACHE"
+                continue
+            }
+            read -r _ _ _ current maximum <<< "$output"
+            [[ "$maximum" =~ ^[0-9]+$ && "$maximum" -gt 0 ]] || return 1
+            printf '%s %s\n' "$bus" "$maximum" > "$DDC_CACHE"
+        fi
+
+        raw=$((percent * maximum / 100))
+        if timeout 5s ddcutil --bus "$bus" setvcp 10 "$raw" >/dev/null 2>&1; then
+            return 0
+        fi
+        rm -f "$DDC_CACHE"
+    done
+
+    return 1
+}
+
+ddc_set() {
+    exec 9>"$DDC_LOCK"
+    flock 9 || return 1
+    ddc_set_locked "$1"
+}
+
+get_brightness() {
+    if has_backlight; then
+        brightnessctl --class=backlight -m 2>/dev/null | awk -F, 'NR == 1 { gsub(/%/, "", $4); print $4 }'
+    else
+        ddc_get
+    fi
+}
+
+set_brightness() {
+    local target=$1
+    local status=0
+    [[ "$target" =~ ^-?[0-9]+$ ]] || return 1
+    (( target < 0 )) && target=0
+    (( target > 100 )) && target=100
+
+    if has_backlight; then
+        brightnessctl --class=backlight set "${target}%" >/dev/null || status=$?
+    else
+        ddc_set "$target" || status=$?
+    fi
+    if (( status == 0 )); then
+        printf '%s\n' "$target" > "$BRIGHTNESS_STATE"
+    else
+        printf '\n' >> "$BRIGHTNESS_STATE"
+    fi
+    return "$status"
+}
+
+adjust_brightness() {
+    local delta=$1
+    local current target
+
+    if has_backlight; then
+        if (( delta > 0 )); then
+            brightnessctl --class=backlight set "${delta}%+" >/dev/null
+        else
+            brightnessctl --class=backlight set "$((-delta))%-" >/dev/null
+        fi
+        return
+    fi
+
+    exec 9>"$DDC_LOCK"
+    flock 9 || return 1
+    current=$(ddc_get_locked) || return 1
+    target=$((current + delta))
+    (( target < 0 )) && target=0
+    (( target > 100 )) && target=100
+    if ddc_set_locked "$target"; then
+        printf '%s\n' "$target" > "$BRIGHTNESS_STATE"
+    else
+        printf '\n' >> "$BRIGHTNESS_STATE"
+        return 1
+    fi
+}
+
+watch_brightness() {
+    local path
+    local paths=("$BRIGHTNESS_STATE")
+
+    touch "$BRIGHTNESS_STATE"
+    for path in /sys/class/backlight/*/brightness; do
+        [[ -e "$path" ]] && paths+=("$path")
+    done
+    inotifywait -m -e modify "${paths[@]}" 2>/dev/null
+}
+
+case "$ACTION" in
+    get)
+        get_brightness
+        ;;
+    set)
+        set_brightness "$VALUE"
+        ;;
+    backend)
+        if has_backlight; then
+            printf 'backlight\n'
+        elif command -v ddcutil >/dev/null 2>&1; then
+            printf 'ddc\n'
+        else
+            printf 'none\n'
+        fi
+        ;;
     raise)
-        brightnessctl set 5%+
+        adjust_brightness 5
         ;;
     lower)
-        brightnessctl set 5%-
+        adjust_brightness -5
+        ;;
+    watch)
+        watch_brightness
+        ;;
+    *)
+        printf 'Unknown brightness action: %s\n' "$ACTION" >&2
+        exit 2
         ;;
 esac


### PR DESCRIPTION
## Summary

This PR focuses on one feature: brightness control for systems without a kernel backlight device.

- centralize brightness get/set/raise/lower operations in `brightness.sh`
- keep `brightnessctl` as the preferred backend and fall back to the first DDC/CI display when no backlight exists
- route the system panel and OSD through the shared backend
- debounce DDC slider writes, serialize monitor access, retry after reconnects, and notify the OSD after changes
- include `ddcutil`/`util-linux` dependencies and enable I2C in the NixOS module

## Testing

- `bash -n src/scripts/brightness.sh`
- `qmllint` on the three modified QML files
- `git diff --check`
- real DDC get/set and raise/lower tests on an Acer EI322QUR connected through NVIDIA DisplayPort
- monitor off/on and suspend/resume recovery

Nix evaluation was not run because Nix is unavailable on the test system.

## Scope

DDC is intentionally a fallback for systems with no kernel backlight. The first detected DDC display is used; mixed internal/external and per-monitor controls are outside this focused change.