### PR TITLE
feat(osd): add microphone OSD support and volume controls

### DIFF
--- a/src/quickshell/popouts/Osd.qml
+++ b/src/quickshell/popouts/Osd.qml
@@ -35,14 +35,31 @@ PanelWindow {
 
     readonly property color briColor: Qt.lighter(ThemeBackend.mauve, 1.1)
     readonly property color volColor: Qt.lighter(ThemeBackend.sapphire, 1.5)
+    readonly property color micColor: Qt.lighter(ThemeBackend.mauve, 1.3)
 
     property bool isVisible: OsdController.isVisible
     property string kind: OsdController.kind
     property int briVal: OsdController.briVal
 
-    readonly property int volVal: Audio.defaultSink && Audio.defaultSink.audio ? Math.round(Audio.defaultSink.audio.volume * 100) : 0
-    readonly property bool isMuted: Audio.defaultSink && Audio.defaultSink.audio ? Audio.defaultSink.audio.muted : false
-    readonly property int currentVal: kind === "volume" ? volVal : briVal
+    readonly property PwNode activeSink: Audio.defaultSink || (Audio.outputs && Audio.outputs.length > 0 ? Audio.outputs[0] : null)
+    readonly property int volVal: activeSink && activeSink.audio ? Math.round(activeSink.audio.volume * 100) : 0
+    readonly property bool isMuted: activeSink && activeSink.audio ? activeSink.audio.muted : false
+
+    readonly property PwNode activeSource: Audio.defaultSource || (Audio.inputs && Audio.inputs.length > 0 ? Audio.inputs[0] : null)
+    readonly property int micVal: activeSource && activeSource.audio ? Math.round(activeSource.audio.volume * 100) : 0
+    readonly property bool isMicMuted: activeSource && activeSource.audio ? activeSource.audio.muted : false
+
+    readonly property bool isMutedState: {
+        if (kind === "volume") return isMuted;
+        if (kind === "mic") return isMicMuted;
+        return false;
+    }
+
+    readonly property int currentVal: {
+        if (kind === "volume") return volVal;
+        if (kind === "mic") return micVal;
+        return briVal;
+    }
 
     property int configRevision: 0
 
@@ -141,12 +158,31 @@ PanelWindow {
         onTriggered: {
             if (targetPct >= 0) {
                 if (targetPct > 0 && osdWindow.isMuted) {
-                    if (Audio.defaultSink && Audio.defaultSink.audio && Audio.defaultSink.audio.muted) {
-                        Audio.toggleMute(Audio.defaultSink);
+                    if (osdWindow.activeSink && osdWindow.activeSink.audio && osdWindow.activeSink.audio.muted) {
+                        Audio.toggleMute(osdWindow.activeSink);
                     }
                 }
-                if (Audio.defaultSink) {
-                    Audio.setVolume(Audio.defaultSink, targetPct);
+                if (osdWindow.activeSink) {
+                    Audio.setVolume(osdWindow.activeSink, targetPct);
+                }
+                targetPct = -1;
+            }
+        }
+    }
+
+    Timer {
+        id: micThrottle
+        interval: 50
+        property int targetPct: -1
+        onTriggered: {
+            if (targetPct >= 0) {
+                if (targetPct > 0 && osdWindow.isMicMuted) {
+                    if (osdWindow.activeSource && osdWindow.activeSource.audio && osdWindow.activeSource.audio.muted) {
+                        Audio.toggleMute(osdWindow.activeSource);
+                    }
+                }
+                if (osdWindow.activeSource) {
+                    Audio.setVolume(osdWindow.activeSource, targetPct);
                 }
                 targetPct = -1;
             }
@@ -517,11 +553,13 @@ PanelWindow {
                 IconButton {
                     Layout.alignment: Qt.AlignHCenter
                     size: osdWindow.s(26)
-                    iconOffsetX: osdWindow.kind === "volume" ? -1 : -3
+                    iconOffsetX: osdWindow.kind === "volume" ? -1 : (osdWindow.kind === "mic" ? 0 : -3)
                     cornerRadius: osdWindow.s(8)
                     buttonIcon: {
                         if (osdWindow.kind === "volume") {
                             return osdWindow.isMuted || osdWindow.volVal === 0 ? "󰖁" : (osdWindow.volVal > 50 ? "󰕾" : "󰖀");
+                        } else if (osdWindow.kind === "mic") {
+                            return osdWindow.isMicMuted || osdWindow.micVal === 0 ? "󰍭" : "󰍬";
                         } else {
                             return osdWindow.briVal > 66 ? "󰃠" : (osdWindow.briVal > 33 ? "󰃟" : "󰃞");
                         }
@@ -532,6 +570,8 @@ PanelWindow {
                         if (isHoveredOrHighlighted) return ThemeBackend.text;
                         if (osdWindow.kind === "volume") {
                             return osdWindow.isMuted ? ThemeBackend.overlay0 : osdWindow.volColor;
+                        } else if (osdWindow.kind === "mic") {
+                            return osdWindow.isMicMuted ? ThemeBackend.overlay0 : osdWindow.micColor;
                         } else {
                             return osdWindow.briColor;
                         }
@@ -539,8 +579,12 @@ PanelWindow {
                     onClicked: {
                         OsdController.restartTimer();
                         if (osdWindow.kind === "volume") {
-                            if (Audio.defaultSink) {
-                                Audio.toggleMute(Audio.defaultSink);
+                            if (osdWindow.activeSink) {
+                                Audio.toggleMute(osdWindow.activeSink);
+                            }
+                        } else if (osdWindow.kind === "mic") {
+                            if (osdWindow.activeSource) {
+                                Audio.toggleMute(osdWindow.activeSource);
                             }
                         } else {
                             briCmdThrottle.stop();
@@ -563,7 +607,15 @@ PanelWindow {
                     value: osdWindow.currentVal
                     backgroundColor: ThemeBackend.surface1
 
-                    readonly property color activeColor: osdWindow.kind === "volume" ? (osdWindow.isMuted ? ThemeBackend.surface2 : osdWindow.volColor) : osdWindow.briColor
+                    readonly property color activeColor: {
+                        if (osdWindow.kind === "volume") {
+                            return osdWindow.isMuted ? ThemeBackend.surface2 : osdWindow.volColor;
+                        } else if (osdWindow.kind === "mic") {
+                            return osdWindow.isMicMuted ? ThemeBackend.surface2 : osdWindow.micColor;
+                        } else {
+                            return osdWindow.briColor;
+                        }
+                    }
 
                     accentColor: activeColor
                     gradColor1: activeColor
@@ -572,15 +624,15 @@ PanelWindow {
                     cornerRadius: osdWindow.s(5)
                     handleSize: osdWindow.s(16)
 
-                    handleColor: (osdWindow.kind === "volume" && osdWindow.isMuted) ? ThemeBackend.overlay0 : Qt.lighter(activeColor, 1.15)
-                    handleHoverColor: (osdWindow.kind === "volume" && osdWindow.isMuted) ? ThemeBackend.subtext0 : Qt.lighter(activeColor, 1.5)
-                    handleDragColor: (osdWindow.kind === "volume" && osdWindow.isMuted) ? ThemeBackend.text : Qt.lighter(activeColor, 1.45)
+                    handleColor: (osdWindow.isMutedState) ? ThemeBackend.overlay0 : Qt.lighter(activeColor, 1.15)
+                    handleHoverColor: (osdWindow.isMutedState) ? ThemeBackend.subtext0 : Qt.lighter(activeColor, 1.5)
+                    handleDragColor: (osdWindow.isMutedState) ? ThemeBackend.text : Qt.lighter(activeColor, 1.45)
                     handleBorderColor: Qt.rgba(0, 0, 0, 0.2)
 
                     onDragStarted: OsdController.cancelHide()
                     onDragFinished: {
                         OsdController.restartTimer();
-                        if (osdWindow.kind !== "volume" && briCmdThrottle.targetPct >= 0) {
+                        if (osdWindow.kind === "brightness" && briCmdThrottle.targetPct >= 0) {
                             briCmdThrottle.stop();
                             Quickshell.execDetached(["bash", Caching.qsDir + "/../scripts/brightness.sh", "set", briCmdThrottle.targetPct.toString()]);
                             briCmdThrottle.targetPct = -1;
@@ -589,15 +641,16 @@ PanelWindow {
                     onMoved: val => {
                         OsdController.restartTimer();
                         let pct = Math.max(0, Math.min(100, Math.round(val)));
-                        if (osdWindow.kind !== "volume") {
+                        if (osdWindow.kind === "brightness") {
                             OsdController.briVal = pct;
-                        }
-                        if (osdWindow.kind === "volume") {
-                            cmdThrottle.targetPct = pct;
-                            if (!cmdThrottle.running) cmdThrottle.start();
-                        } else {
                             briCmdThrottle.targetPct = pct;
                             if (!verticalSlider.isDragging) briCmdThrottle.restart();
+                        } else if (osdWindow.kind === "volume") {
+                            cmdThrottle.targetPct = pct;
+                            if (!cmdThrottle.running) cmdThrottle.start();
+                        } else if (osdWindow.kind === "mic") {
+                            micThrottle.targetPct = pct;
+                            if (!micThrottle.running) micThrottle.start();
                         }
                     }
                 }
@@ -617,10 +670,12 @@ PanelWindow {
                         anchors.centerIn: parent
                         size: osdWindow.s(30)
                         cornerRadius: osdWindow.s(8)
-                        iconOffsetX: osdWindow.kind === "volume" ? -1 : -3
+                        iconOffsetX: osdWindow.kind === "volume" ? -1 : (osdWindow.kind === "mic" ? 0 : -3)
                         buttonIcon: {
                             if (osdWindow.kind === "volume") {
                                 return osdWindow.isMuted || osdWindow.volVal === 0 ? "󰖁" : (osdWindow.volVal > 50 ? "󰕾" : "󰖀");
+                            } else if (osdWindow.kind === "mic") {
+                                return osdWindow.isMicMuted || osdWindow.micVal === 0 ? "󰍭" : "󰍬";
                             } else {
                                 return osdWindow.briVal > 66 ? "󰃠" : (osdWindow.briVal > 33 ? "󰃟" : "󰃞");
                             }
@@ -631,6 +686,8 @@ PanelWindow {
                             if (isHoveredOrHighlighted) return ThemeBackend.text;
                             if (osdWindow.kind === "volume") {
                                 return osdWindow.isMuted ? ThemeBackend.overlay0 : osdWindow.volColor;
+                            } else if (osdWindow.kind === "mic") {
+                                return osdWindow.isMicMuted ? ThemeBackend.overlay0 : osdWindow.micColor;
                             } else {
                                 return osdWindow.briColor;
                             }
@@ -638,8 +695,12 @@ PanelWindow {
                         onClicked: {
                             OsdController.restartTimer();
                             if (osdWindow.kind === "volume") {
-                                if (Audio.defaultSink) {
-                                    Audio.toggleMute(Audio.defaultSink);
+                                if (osdWindow.activeSink) {
+                                    Audio.toggleMute(osdWindow.activeSink);
+                                }
+                            } else if (osdWindow.kind === "mic") {
+                                if (osdWindow.activeSource) {
+                                    Audio.toggleMute(osdWindow.activeSource);
                                 }
                             } else {
                                 briCmdThrottle.stop();
@@ -667,7 +728,15 @@ PanelWindow {
                     value: osdWindow.currentVal
                     backgroundColor: ThemeBackend.surface1
 
-                    readonly property color activeColor: osdWindow.kind === "volume" ? (osdWindow.isMuted ? ThemeBackend.surface2 : osdWindow.volColor) : osdWindow.briColor
+                    readonly property color activeColor: {
+                        if (osdWindow.kind === "volume") {
+                            return osdWindow.isMuted ? ThemeBackend.surface2 : osdWindow.volColor;
+                        } else if (osdWindow.kind === "mic") {
+                            return osdWindow.isMicMuted ? ThemeBackend.surface2 : osdWindow.micColor;
+                        } else {
+                            return osdWindow.briColor;
+                        }
+                    }
 
                     accentColor: activeColor
                     gradColor1: activeColor
@@ -676,15 +745,15 @@ PanelWindow {
                     cornerRadius: osdWindow.s(5)
                     handleSize: osdWindow.s(16)
 
-                    handleColor: (osdWindow.kind === "volume" && osdWindow.isMuted) ? ThemeBackend.overlay0 : Qt.lighter(activeColor, 1.15)
-                    handleHoverColor: (osdWindow.kind === "volume" && osdWindow.isMuted) ? ThemeBackend.subtext0 : Qt.lighter(activeColor, 1.5)
-                    handleDragColor: (osdWindow.kind === "volume" && osdWindow.isMuted) ? ThemeBackend.text : Qt.lighter(activeColor, 1.45)
+                    handleColor: (osdWindow.isMutedState) ? ThemeBackend.overlay0 : Qt.lighter(activeColor, 1.15)
+                    handleHoverColor: (osdWindow.isMutedState) ? ThemeBackend.subtext0 : Qt.lighter(activeColor, 1.5)
+                    handleDragColor: (osdWindow.isMutedState) ? ThemeBackend.text : Qt.lighter(activeColor, 1.45)
                     handleBorderColor: Qt.rgba(0, 0, 0, 0.2)
 
                     onDragStarted: OsdController.cancelHide()
                     onDragFinished: {
                         OsdController.restartTimer();
-                        if (osdWindow.kind !== "volume" && briCmdThrottle.targetPct >= 0) {
+                        if (osdWindow.kind === "brightness" && briCmdThrottle.targetPct >= 0) {
                             briCmdThrottle.stop();
                             Quickshell.execDetached(["bash", Caching.qsDir + "/../scripts/brightness.sh", "set", briCmdThrottle.targetPct.toString()]);
                             briCmdThrottle.targetPct = -1;
@@ -693,15 +762,16 @@ PanelWindow {
                     onMoved: val => {
                         OsdController.restartTimer();
                         let pct = Math.max(0, Math.min(100, Math.round(val)));
-                        if (osdWindow.kind !== "volume") {
+                        if (osdWindow.kind === "brightness") {
                             OsdController.briVal = pct;
-                        }
-                        if (osdWindow.kind === "volume") {
-                            cmdThrottle.targetPct = pct;
-                            if (!cmdThrottle.running) cmdThrottle.start();
-                        } else {
                             briCmdThrottle.targetPct = pct;
                             if (!horizontalSlider.isDragging) briCmdThrottle.restart();
+                        } else if (osdWindow.kind === "volume") {
+                            cmdThrottle.targetPct = pct;
+                            if (!cmdThrottle.running) cmdThrottle.start();
+                        } else if (osdWindow.kind === "mic") {
+                            micThrottle.targetPct = pct;
+                            if (!micThrottle.running) micThrottle.start();
                         }
                     }
                 }

--- a/src/quickshell/singletons/widgetcontrols/OsdController.qml
+++ b/src/quickshell/singletons/widgetcontrols/OsdController.qml
@@ -15,13 +15,20 @@ Item {
     property bool isHovered: false
     property bool isFullscreen: false
 
-    readonly property real sysVolume: Audio.defaultSink && Audio.defaultSink.audio ? Math.round(Audio.defaultSink.audio.volume * 100) : 0
-    readonly property bool sysMuted: Audio.defaultSink && Audio.defaultSink.audio ? Audio.defaultSink.audio.muted : false
+    readonly property PwNode activeSink: Audio.defaultSink || (Audio.outputs && Audio.outputs.length > 0 ? Audio.outputs[0] : null)
+    readonly property real sysVolume: activeSink && activeSink.audio ? Math.round(activeSink.audio.volume * 100) : 0
+    readonly property bool sysMuted: activeSink && activeSink.audio ? activeSink.audio.muted : false
+
+    readonly property PwNode activeSource: Audio.defaultSource || (Audio.inputs && Audio.inputs.length > 0 ? Audio.inputs[0] : null)
+    readonly property real sysMicVolume: activeSource && activeSource.audio ? Math.round(activeSource.audio.volume * 100) : 0
+    readonly property bool sysMicMuted: activeSource && activeSource.audio ? activeSource.audio.muted : false
 
     property int sysBrightness: 0
 
     property real lastVolume: -1
     property bool lastMuted: false
+    property real lastMicVolume: -1
+    property bool lastMicMuted: false
     property int lastBrightness: -1
     property bool brightnessInitialized: false
     property bool isInitialized: false
@@ -45,6 +52,8 @@ Item {
         onTriggered: {
             controller.lastVolume = controller.sysVolume;
             controller.lastMuted = controller.sysMuted;
+            controller.lastMicVolume = controller.sysMicVolume;
+            controller.lastMicMuted = controller.sysMicMuted;
             controller.lastBrightness = controller.sysBrightness;
             controller.isInitialized = true;
         }
@@ -63,6 +72,22 @@ Item {
         if (controller.lastMuted !== controller.sysMuted) {
             controller.lastMuted = controller.sysMuted;
             controller.show("volume");
+        }
+    }
+
+    onSysMicVolumeChanged: {
+        if (!controller.isInitialized) return;
+        if (controller.lastMicVolume !== controller.sysMicVolume) {
+            controller.lastMicVolume = controller.sysMicVolume;
+            controller.show("mic");
+        }
+    }
+
+    onSysMicMutedChanged: {
+        if (!controller.isInitialized) return;
+        if (controller.lastMicMuted !== controller.sysMicMuted) {
+            controller.lastMicMuted = controller.sysMicMuted;
+            controller.show("mic");
         }
     }
 
@@ -119,7 +144,7 @@ Item {
 
     function show(k, v, scr) {
         controller.kind = k || "volume";
-        if (controller.kind !== "volume" && v !== undefined) {
+        if (controller.kind === "brightness" && v !== undefined) {
             controller.briVal = parseInt(v) || 0;
         }
         if (scr !== undefined && scr !== null) {

--- a/src/scripts/volume.sh
+++ b/src/scripts/volume.sh
@@ -17,4 +17,10 @@ case $ACTION in
     mic-toggle)
         wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle
         ;;
+    mic-raise)
+        wpctl set-volume -l 1.0 @DEFAULT_AUDIO_SOURCE@ 5%+
+        ;;
+    mic-lower)
+        wpctl set-volume @DEFAULT_AUDIO_SOURCE@ 5%-
+        ;;
 esac


### PR DESCRIPTION
--- Title ---
  
    Add microphone OSD support and volume controls
  
 --- Description ---
  
    Adds PipeWire listeners and OSD popup support for microphone mute and volume controls.
  
    Changes:
    - OSD now handles microphone state with mute/unmute icons and slider controls
    - OsdController listens to PipeWire defaultSource volume and mute changes
    - Added mic-raise and mic-lower commands to volume.sh
  
    Commands:
    - serpantinum volume mic-toggle
    - serpantinum volume mic-raise
    - serpantinum volume mic-lower
  
    Tested and working on Hyprland, Sway, Niri and NixOS.