### PR TITLE
Add fullscreen toggle keybind for F12

### DIFF
--- a/compositors/hyprland/config/keybinds.lua
+++ b/compositors/hyprland/config/keybinds.lua
@@ -22,6 +22,7 @@ hl.bind(mainMod .. " + Down", hl.dsp.focus({ direction = "down" }))
 
 hl.bind("ALT + F4", hl.dsp.window.close())
 hl.bind(mainMod .. " + SHIFT + F", hl.dsp.window.float({ action = "toggle" }))
+hl.bind(mainMod .. " + F12", hl.dsp.window.fullscreen({ action = "toggle" }))
 
 hl.bind("XF86MonBrightnessDown", hl.dsp.exec_cmd("serpantinum brightness lower"), { locked = true })
 hl.bind("XF86MonBrightnessUp", hl.dsp.exec_cmd("serpantinum brightness raise"), { locked = true })


### PR DESCRIPTION
Added support for toggling full-screen of the application in focus by pressing `SUPER + F12`.