### PR TITLE
fix: show system monitor on the correct screen

### DIFF
--- a/src/quickshell/bar/modules/system/SysMonWidget.qml
+++ b/src/quickshell/bar/modules/system/SysMonWidget.qml
@@ -271,7 +271,7 @@ Rectangle {
         anchors.fill: parent
         cursorShape: Qt.PointingHandCursor
         onClicked: {
-            Quickshell.execDetached(["quickshell", "-p", Caching.mainQml, "ipc", "call", "floating", "showSystemUsage"]);
+            FloatingController.showSystemUsage(sysMonWidgetRoot.barWindow ? sysMonWidgetRoot.barWindow.screen : null);
         }
     }
 }

--- a/src/quickshell/bar/sidemodules/system/SideSysMonWidget.qml
+++ b/src/quickshell/bar/sidemodules/system/SideSysMonWidget.qml
@@ -238,7 +238,7 @@ Rectangle {
         anchors.fill: parent
         cursorShape: Qt.PointingHandCursor
         onClicked: {
-            Quickshell.execDetached(["quickshell", "-p", Caching.mainQml, "ipc", "call", "floating", "showSystemUsage"]);
+            FloatingController.showSystemUsage(sideSysMonRoot.barWindow ? sideSysMonRoot.barWindow.screen : null);
         }
     }
 }

--- a/src/quickshell/qmldir
+++ b/src/quickshell/qmldir
@@ -33,6 +33,7 @@ singleton LauncherController 1.0 singletons/widgetcontrols/LauncherController.qm
 singleton OsdController 1.0 singletons/widgetcontrols/OsdController.qml
 singleton SideMusicController 1.0 singletons/widgetcontrols/SideMusicController.qml
 singleton ClipboardController 1.0 singletons/widgetcontrols/ClipboardController.qml
+singleton FloatingController 1.0 singletons/widgetcontrols/FloatingController.qml
 
 PopoutManager 1.0 popouts/PopoutManager.qml
 
@@ -61,7 +62,6 @@ singleton NotificationManager 1.0 notifications/NotificationManager.qml
 Floating 1.0 quickactions/Floating.qml
 
 Bar 1.0 bar/Bar.qml
-
 
 
 

--- a/src/quickshell/quickactions/Floating.qml
+++ b/src/quickshell/quickactions/Floating.qml
@@ -119,35 +119,48 @@ Variants {
 
             property int tabCount: Math.max(1, tabModules.length)
 
-            IpcHandler {
-                target: "floating"
+            Connections {
+                target: FloatingController
 
-                function setIndex(idx: string) {
-                    let newIdx = parseInt(idx);
-                    if (!isNaN(newIdx) && newIdx >= 0 && newIdx < floatingWidget.tabCount) {
-                        floatingWidget.activeIndex = newIdx;
+                function onSetIndexRequested(screen, index) {
+                    if (floatingWidget.matchesScreen(screen)) {
+                        floatingWidget.setIndex(index);
                     }
                 }
 
-                function showSystemUsage() {
-                    let sysIndex = 1;
-                    for (let i = 0; i < floatingWidget.tabModules.length; i++) {
-                        if (floatingWidget.tabModules[i].indexOf("SystemUsage") !== -1) {
-                            sysIndex = i;
-                            break;
-                        }
+                function onShowSystemUsageRequested(screen) {
+                    if (floatingWidget.matchesScreen(screen)) {
+                        floatingWidget.showSystemUsage();
                     }
-                    floatingWidget.activeIndex = sysIndex;
-                    let sideEdge = (floatingWidget.barPosition === "left") ? "right" : "left";
-                    let centerPos = floatingWidget.height / 2;
-                    floatingWidget.useGraceTimer = true;
-                    floatingWidget.showSidebar(sideEdge, centerPos, true);
-                    hideTimer.restart();
                 }
+            }
 
-                function forceReload() {
-                    Quickshell.reload(true)
+            function matchesScreen(targetScreen) {
+                return targetScreen && floatingWidget.screen
+                    && (targetScreen === floatingWidget.screen || targetScreen.name === floatingWidget.screen.name);
+            }
+
+            function setIndex(index) {
+                let newIndex = parseInt(index);
+                if (!isNaN(newIndex) && newIndex >= 0 && newIndex < floatingWidget.tabCount) {
+                    floatingWidget.activeIndex = newIndex;
                 }
+            }
+
+            function showSystemUsage() {
+                let sysIndex = 1;
+                for (let i = 0; i < floatingWidget.tabModules.length; i++) {
+                    if (floatingWidget.tabModules[i].indexOf("SystemUsage") !== -1) {
+                        sysIndex = i;
+                        break;
+                    }
+                }
+                floatingWidget.activeIndex = sysIndex;
+                let sideEdge = (floatingWidget.barPosition === "left") ? "right" : "left";
+                let centerPos = floatingWidget.height / 2;
+                floatingWidget.useGraceTimer = true;
+                floatingWidget.showSidebar(sideEdge, centerPos, true);
+                hideTimer.restart();
             }
 
             function childIntercepts(sequenceStr) {

--- a/src/quickshell/singletons/widgetcontrols/FloatingController.qml
+++ b/src/quickshell/singletons/widgetcontrols/FloatingController.qml
@@ -1,0 +1,44 @@
+pragma Singleton
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import "../../"
+
+Item {
+    id: controller
+
+    signal setIndexRequested(var screen, string index)
+    signal showSystemUsageRequested(var screen)
+
+    function targetScreen(screen) {
+        if (screen) return screen;
+        if (Quickshell.cursorScreen) return Quickshell.cursorScreen;
+        return Quickshell.screens && Quickshell.screens.length > 0 ? Quickshell.screens[0] : null;
+    }
+
+    function setIndex(index, screen) {
+        let target = targetScreen(screen);
+        if (target) controller.setIndexRequested(target, index);
+    }
+
+    function showSystemUsage(screen) {
+        let target = targetScreen(screen);
+        if (target) controller.showSystemUsageRequested(target);
+    }
+
+    IpcHandler {
+        target: "floating"
+
+        function setIndex(index: string) {
+            controller.setIndex(index, null);
+        }
+
+        function showSystemUsage() {
+            controller.showSystemUsage(null);
+        }
+
+        function forceReload() {
+            Quickshell.reload(true)
+        }
+    }
+}


### PR DESCRIPTION
bug: clicking the system monitor widget could open the floating panel on the wrong monitor

so, this pull request fixes it