### PR TITLE
feat(lock): surface PAM fingerprint feedback on lock screen

### DIFF
--- a/src/assets/languages/en.json
+++ b/src/assets/languages/en.json
@@ -534,7 +534,8 @@
       "locked": "Locked",
       "access_denied": "Access denied",
       "authenticating": "Authenticating...",
-      "enter_pin": "Enter PIN"
+      "enter_pin": "Enter PIN",
+      "fingerprint_retry": "Fingerprint not recognized, try again"
     },
     "power": {
       "suspend": "Suspend",

--- a/src/quickshell/lock/Lock.qml
+++ b/src/quickshell/lock/Lock.qml
@@ -24,6 +24,7 @@ Scope {
     property bool isSway: false
     property string kbLayout: "US"
     property int connectedScreenCount: 1
+    property bool dualAuthAvailable: false
 
     readonly property bool isDesktop: UPower.displayDevice.ready ? !UPower.displayDevice.isLaptopBattery : SystemInfo.isDesktop
     readonly property int batCap: UPower.displayDevice.ready ? Math.round(UPower.displayDevice.percentage * 100) : 0
@@ -53,6 +54,7 @@ Scope {
         SystemInfo.fetch();
         root.updateDeInfo();
         root.updateScreenCount();
+        pamConfigCheck.running = true;
     }
 
     Connections {
@@ -81,6 +83,15 @@ Scope {
             kbWaiter.running = false;
             kbPoller.running = false;
             if (rootLock.locked) kbPoller.running = true;
+        }
+    }
+
+    Process {
+        id: pamConfigCheck
+        command: ["test", "-f", "/etc/pam.d/quickshell-fprint"]
+        onExited: (exitCode) => {
+            root.dualAuthAvailable = (exitCode === 0);
+            pamPassword.config = root.dualAuthAvailable ? "quickshell-password" : "quickshell";
         }
     }
 
@@ -192,15 +203,8 @@ Scope {
         lockUI.authenticating = false;
         lockUI.statusText = I18n.t("lock.status.locked");
         rootLock.locked = true;
-        pamActionTimer.start();
+        if (root.dualAuthAvailable) fingerprintRetryTimer.start();
         kbPollerRestartTimer.restart();
-    }
-
-    function startAuth() {
-        lockUI.failed = false;
-        lockUI.authenticating = true;
-        lockUI.statusText = I18n.t("lock.status.authenticating");
-        pam.start();
     }
 
     function finishUnlock() {
@@ -241,27 +245,47 @@ Scope {
         property string statusText: I18n.t("lock.status.locked")
     }
 
-    Timer {
-        id: pamActionTimer
+        Timer {
+        id: fingerprintRetryTimer
         interval: 350
         onTriggered: {
-            if (rootLock.locked) {
-                startAuth();
+            if (!rootLock.locked || root.isUnlocking || !root.dualAuthAvailable) return;
+            if (!pamFingerprint.start()) {
+                fingerprintRetryTimer.start();
             }
         }
     }
 
     PamContext {
-        id: pam
+        id: pamFingerprint
+        config: "quickshell-fprint"
 
         onPamMessage: {
-            if (pam.message !== "") {
-                if (pam.messageIsError) {
-                    lockUI.statusText = I18n.t("lock.status.fingerprint_retry");
-                } else {
-                    lockUI.statusText = pam.message;
-                }
-                lockUI.failed = pam.messageIsError;
+            if (pamFingerprint.message !== "") {
+                lockUI.statusText = pamFingerprint.messageIsError
+                    ? I18n.t("lock.status.fingerprint_retry")
+                    : pamFingerprint.message;
+            }
+        }
+
+        onCompleted: (result) => {
+            if (result === PamResult.Success) {
+                root.finishUnlock();
+            } else if (root.dualAuthAvailable) {
+                fingerprintRetryTimer.start();
+            }
+        }
+    }
+
+    PamContext {
+        id: pamPassword
+        config: "quickshell"
+        property string pendingPassword: ""
+
+        onResponseRequiredChanged: {
+            if (responseRequired && pendingPassword !== "") {
+                respond(pendingPassword);
+                pendingPassword = "";
             }
         }
 
@@ -272,7 +296,6 @@ Scope {
             } else {
                 lockUI.failed = true;
                 lockUI.statusText = I18n.t("lock.status.access_denied");
-                pamActionTimer.start();
             }
         }
     }
@@ -283,10 +306,10 @@ Scope {
         onExited: {
             SystemInfo.fetch();
             root.updateDeInfo();
-            pamActionTimer.restart();
             kbPollerRestartTimer.restart();
-            if (rootLock.locked) {
-                startAuth();
+            if (rootLock.locked && root.dualAuthAvailable) {
+                fingerprintRetryTimer.restart();
+                pamFingerprint.start();
             }
         }
     }
@@ -1538,11 +1561,12 @@ Scope {
                                                 isRevealed: !lockSettings.hidePassword
 
                                                 onAccepted: (finalText) => {
-                                                    if (finalText.length > 0 && pam.responseRequired && !lockUI.authenticating) {
+                                                    if (finalText.length > 0 && !lockUI.authenticating) {
                                                         lockUI.authenticating = true;
                                                         lockUI.statusText = I18n.t("lock.status.authenticating");
                                                         lockUI.failed = false;
-                                                        pam.respond(finalText);
+                                                        pamPassword.pendingPassword = finalText;
+                                                        pamPassword.start();
                                                     }
                                                 }
 

--- a/src/quickshell/lock/Lock.qml
+++ b/src/quickshell/lock/Lock.qml
@@ -196,6 +196,12 @@ Scope {
         kbPollerRestartTimer.restart();
     }
 
+    function startAuth() {
+        lockUI.failed = false;
+        lockUI.statusText = I18n.t("lock.status.authenticating");
+        pam.start();
+    }
+
     function finishUnlock() {
         if (root.isUnlocking) return;
         root.isUnlocking = true;
@@ -239,13 +245,24 @@ Scope {
         interval: 350
         onTriggered: {
             if (rootLock.locked) {
-                pam.start();
+                startAuth();
             }
         }
     }
 
     PamContext {
         id: pam
+
+        onPamMessage: {
+            if (message !== "") {
+                if (message.toLowerCase().includes("failed to match") || message.toLowerCase().includes("no match")) {
+                    lockUI.statusText = I18n.t("lock.status.fingerprint_retry");
+                } else {
+                    lockUI.statusText = message;
+                }
+                lockUI.failed = messageIsError;
+            }
+        }
 
         onCompleted: (result) => {
             lockUI.authenticating = false;
@@ -268,7 +285,7 @@ Scope {
             pamActionTimer.restart();
             kbPollerRestartTimer.restart();
             if (rootLock.locked) {
-                pam.start();
+                startAuth();
             }
         }
     }

--- a/src/quickshell/lock/Lock.qml
+++ b/src/quickshell/lock/Lock.qml
@@ -198,6 +198,7 @@ Scope {
 
     function startAuth() {
         lockUI.failed = false;
+        lockUI.authenticating = true;
         lockUI.statusText = I18n.t("lock.status.authenticating");
         pam.start();
     }
@@ -254,13 +255,13 @@ Scope {
         id: pam
 
         onPamMessage: {
-            if (message !== "") {
-                if (message.toLowerCase().includes("failed to match") || message.toLowerCase().includes("no match")) {
+            if (pam.message !== "") {
+                if (pam.messageIsError) {
                     lockUI.statusText = I18n.t("lock.status.fingerprint_retry");
                 } else {
-                    lockUI.statusText = message;
+                    lockUI.statusText = pam.message;
                 }
-                lockUI.failed = messageIsError;
+                lockUI.failed = pam.messageIsError;
             }
         }
 


### PR DESCRIPTION
Adds handling for PamContext.pamMessage to show retry feedback when a fingerprint scan fails (e.g. finger repositioning needed), instead of only reacting to final onCompleted result. Also resets stale status/error state via a new startAuth() helper before each new PAM attempt.

## PR guidelines: 
### Before opening a pull request, please read the following:

Each pull request should focus on exactly one feature or one bug fix.

Good examples:

Add support for X
Fix crash when Y happens 
Improve performance of Z

Not good examples:

Add support for X
Fix three unrelated bugs
Refactor several modules
Update translations

all in the same PR. 

If you have multiple improvements to contribute, please split them into separate pull requests. Smaller, focused PRs are significantly more likely to get accepted. A pull request may be technically correct, well-written, and fully tested, and still not be accepted. I must be able to agree with every change included in the PR. If a PR contains several unrelated changes and even one of them is not something I want to include, the entire PR may be rejected or asked to be split apart, like I was already doing.

Translation-related pull requests are always welcome.
