### PR TITLE
i18n: add fingerprint_retry translations

### DIFF
--- a/src/assets/languages/de.json
+++ b/src/assets/languages/de.json
@@ -578,7 +578,8 @@
       "locked": "Gesperrt",
       "access_denied": "Zugriff verweigert",
       "authenticating": "Authentifizierung läuft...",
-      "enter_pin": "PIN eingeben"
+      "enter_pin": "PIN eingeben",
+      "fingerprint_retry": "Fingerabdruck nicht erkannt, bitte erneut versuchen"
     },
     "power": {
       "suspend": "Standby",

--- a/src/assets/languages/es.json
+++ b/src/assets/languages/es.json
@@ -578,7 +578,8 @@
       "locked": "Bloqueado",
       "access_denied": "Acceso denegado",
       "authenticating": "Autenticando...",
-      "enter_pin": "Introduce el PIN"
+      "enter_pin": "Introduce el PIN",
+      "fingerprint_retry": "Huella no reconocida, inténtalo de nuevo"
     },
     "power": {
       "suspend": "Suspender",

--- a/src/assets/languages/hy.json
+++ b/src/assets/languages/hy.json
@@ -534,7 +534,8 @@
       "locked": "Կողպված է",
       "access_denied": "Մուտքը մերժված է",
       "authenticating": "Նույնականացում...",
-      "enter_pin": "Մուտքագրեք PIN-ը"
+      "enter_pin": "Մուտքագրեք PIN-ը",
+      "fingerprint_retry": "Մատնահետքը չի ճանաչվել, փորձեք կրկին"
     },
     "power": {
       "suspend": "Քնեցնել",

--- a/src/assets/languages/it.json
+++ b/src/assets/languages/it.json
@@ -533,7 +533,8 @@
       "locked": "Bloccato",
       "access_denied": "Accesso negato",
       "authenticating": "Autenticazione...",
-      "enter_pin": "Inserisci il PIN"
+      "enter_pin": "Inserisci il PIN",
+      "fingerprint_retry": "Impronta non riconosciuta, riprova"
     },
     "power": {
       "suspend": "Sospendi",

--- a/src/assets/languages/ko.json
+++ b/src/assets/languages/ko.json
@@ -534,7 +534,8 @@
       "locked": "잠김",
       "access_denied": "접근이 거부되었습니다",
       "authenticating": "인증 중...",
-      "enter_pin": "PIN 입력"
+      "enter_pin": "PIN 입력",
+      "fingerprint_retry": "지문이 인식되지 않았습니다. 다시 시도해주세요"
     },
     "power": {
       "suspend": "절전",

--- a/src/assets/languages/ru.json
+++ b/src/assets/languages/ru.json
@@ -578,7 +578,8 @@
       "locked": "Заблокировано",
       "access_denied": "Отказано в доступе",
       "authenticating": "Аутентификация...",
-      "enter_pin": "Введите PIN"
+      "enter_pin": "Введите PIN",
+      "fingerprint_retry": "Отпечаток не распознан, попробуйте ещё раз"
     },
     "power": {
       "suspend": "Сон",

--- a/src/assets/languages/vi.json
+++ b/src/assets/languages/vi.json
@@ -534,7 +534,8 @@
       "locked": "Đã khóa",
       "access_denied": "Truy cập bị từ chối",
       "authenticating": "Đang xác thực...",
-      "enter_pin": "Nhập mã PIN"
+      "enter_pin": "Nhập mã PIN",
+      "fingerprint_retry": "Không nhận dạng được vân tay, vui lòng thử lại"
     },
     "power": {
       "suspend": "Ngủ",


### PR DESCRIPTION
Adds the `lock.status.fingerprint_retry` translation key for de/es/hy/it/ru/vi, complementing the English string added in #223 .

## PR guidelines: 
### Before opening a pull request, please read the following:

Each pull request should focus on exactly one feature or one bug fix.

Good examples:

Add support for X
Fix crash when Y happens 
Improve performance of Z

Not good examples:

Add support for X
Fix three unrelated bugs
Refactor several modules
Update translations

all in the same PR. 

If you have multiple improvements to contribute, please split them into separate pull requests. Smaller, focused PRs are significantly more likely to get accepted. A pull request may be technically correct, well-written, and fully tested, and still not be accepted. I must be able to agree with every change included in the PR. If a PR contains several unrelated changes and even one of them is not something I want to include, the entire PR may be rejected or asked to be split apart, like I was already doing.

Translation-related pull requests are always welcome.
