### PR TITLE
Fix static theme templates: fastfetch filename typo, missing Hyprland template

### DIFF
--- a/src/assets/matugen/config-static.toml
+++ b/src/assets/matugen/config-static.toml
@@ -11,4 +11,8 @@ output_path = "~/.config/cava/config"
 
 [templates.fastfetch]
 input_path = "templates/fastfetch.jsonc.template"
-output_path = "~/.config/fastfetch/fastfetch.jsonc"
+output_path = "~/.config/fastfetch/config.jsonc"
+
+[templates.hyprland]
+input_path = "templates/hyprland-colors.lua.template"
+output_path = "~/.config/hypr/config/matugen-colors.lua"

--- a/src/assets/matugen/templates/hyprland-colors.lua.template
+++ b/src/assets/matugen/templates/hyprland-colors.lua.template
@@ -1,0 +1,8 @@
+hl.config({
+    general = {
+        col = {
+            active_border = "rgb({{colors.primary.default.hex_stripped}})",
+            inactive_border = "rgb({{colors.surface_variant.default.hex_stripped}})",
+        },
+    },
+})


### PR DESCRIPTION
Two small fixes to config-static.toml (the static theme variant of the matugen config, used by Matugen.qml's generateFromStatic):

1. [templates.fastfetch] output_path was ~/.config/fastfetch/fastfetch.jsonc, but fastfetch reads from config.jsonc — so static theme selection was rendering fastfetch colors correctly but to a file fastfetch never reads. Fixed to match config.toml's correct path.

2. [templates.hyprland] was present in config.toml (see #225) but missing here, so static theme selection never touched Hyprland border colors at all. Added the same template block, using the same hyprland-colors.lua.template and output path.

Confirmed via inotify/auditd that generateFromStatic's matugen invocation runs correctly on theme selection — these were purely config gaps, not a QML/logic bug.