### PR TITLE
feat(screenshot): optionally capture the region on mouse release

### DIFF
--- a/src/assets/languages/en.json
+++ b/src/assets/languages/en.json
@@ -219,6 +219,10 @@
         "title": "Copy settings",
         "desc": "Copy configuration JSON to clipboard",
         "button": "Copy settings"
+      },
+      "screenshot_on_release": {
+        "title": "Capture region on mouse release",
+        "desc": "Take the screenshot as soon as you finish dragging, without clicking the shutter"
       }
     },
     "display": {

--- a/src/quickshell/guide/general/GeneralTab.qml
+++ b/src/quickshell/guide/general/GeneralTab.qml
@@ -37,6 +37,7 @@ Item {
         "avatarPath": "",
         "muteSfx": false,
         "sfxVolume": 100,
+        "screenshotCaptureOnRelease": false,
         "weatherInterval": 15,
         "weatherUnit": "metric",
         "quickactions": true
@@ -46,6 +47,7 @@ Item {
     property string currentLanguage: generalSettings.language !== undefined ? generalSettings.language : "en"
     property bool muteSfx: generalSettings.muteSfx !== undefined ? generalSettings.muteSfx : false
     property real sfxVolume: generalSettings.sfxVolume !== undefined ? generalSettings.sfxVolume : 100
+    property bool screenshotCaptureOnRelease: generalSettings.screenshotCaptureOnRelease !== undefined ? generalSettings.screenshotCaptureOnRelease : false
     property bool quickactions: generalSettings.quickactions !== undefined ? generalSettings.quickactions : true
     property int weatherInterval: generalSettings.weatherInterval !== undefined ? generalSettings.weatherInterval : 15
     property string weatherUnit: generalSettings.weatherUnit !== undefined ? generalSettings.weatherUnit : "metric"
@@ -82,6 +84,7 @@ Item {
             generalTabRoot.currentLanguage = gs.language !== undefined ? gs.language : "en";
             generalTabRoot.muteSfx = gs.muteSfx !== undefined ? gs.muteSfx : false;
             generalTabRoot.sfxVolume = gs.sfxVolume !== undefined ? gs.sfxVolume : 100;
+            generalTabRoot.screenshotCaptureOnRelease = gs.screenshotCaptureOnRelease !== undefined ? gs.screenshotCaptureOnRelease : false;
             generalTabRoot.quickactions = gs.quickactions !== undefined ? gs.quickactions : true;
             generalTabRoot.weatherInterval = gs.weatherInterval !== undefined ? gs.weatherInterval : 15;
             generalTabRoot.weatherUnit = gs.weatherUnit !== undefined ? gs.weatherUnit : "metric";
@@ -111,6 +114,7 @@ Item {
         current.avatarPath = generalTabRoot.currentAvatarSourcePath;
         current.muteSfx = generalTabRoot.muteSfx;
         current.sfxVolume = generalTabRoot.sfxVolume;
+        current.screenshotCaptureOnRelease = generalTabRoot.screenshotCaptureOnRelease;
         current.quickactions = generalTabRoot.quickactions;
         current.weatherInterval = generalTabRoot.weatherInterval;
         current.weatherUnit = generalTabRoot.weatherUnit;
@@ -564,6 +568,51 @@ Item {
                 color: Qt.alpha(ThemeBackend.surface1, 0.2)
                 Layout.topMargin: rootObj.s(5)
                 Layout.bottomMargin: rootObj.s(5)
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                implicitHeight: rowShotReleaseLayout.implicitHeight + rootObj.s(18)
+                color: "transparent"
+
+                RowLayout {
+                    id: rowShotReleaseLayout
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    spacing: rootObj.s(16)
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: rootObj.s(2)
+                        Text {
+                            text: I18n.t("guide.general.screenshot_on_release.title") || "Capture region on mouse release"
+                            font.family: ThemeBackend.fontFamily
+                            font.pixelSize: rootObj.s(13)
+                            color: ThemeBackend.text
+                        }
+                        Text {
+                            text: I18n.t("guide.general.screenshot_on_release.desc") || "Take the screenshot as soon as you finish dragging, without clicking the shutter"
+                            font.family: ThemeBackend.fontFamily
+                            font.pixelSize: rootObj.s(11)
+                            color: ThemeBackend.subtext0
+                        }
+                    }
+
+                    Toggle {
+                        Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                        Layout.rightMargin: rootObj.s(8)
+                        checked: generalTabRoot.screenshotCaptureOnRelease
+                        accentColor: ThemeBackend.mauve
+                        baseColor: ThemeBackend.surface1
+                        handleColor: ThemeBackend.crust
+                        handleOffColor: ThemeBackend.text
+                        onToggled: function(c) {
+                            generalTabRoot.screenshotCaptureOnRelease = c;
+                            generalTabRoot.updateGeneralSettings();
+                        }
+                    }
+                }
             }
 
             Rectangle {

--- a/src/quickshell/screenshot/ScreenshotOverlay.qml
+++ b/src/quickshell/screenshot/ScreenshotOverlay.qml
@@ -24,6 +24,18 @@ PanelWindow {
 
     property string targetMonitorName: ""
 
+    // Take the shot as soon as the region drag ends, instead of requiring a
+    // second click on the toolbar shutter. Off by default.
+    property var generalSettings: Config.getSetting("general", { "screenshotCaptureOnRelease": false })
+    readonly property bool captureOnRelease: generalSettings && generalSettings.screenshotCaptureOnRelease === true
+
+    Connections {
+        target: Config
+        function onSettingsLoaded() {
+            root.generalSettings = Config.getSetting("general", { "screenshotCaptureOnRelease": false });
+        }
+    }
+
     property var targetScreen: {
         if (targetMonitorName !== "") {
             for (let i = 0; i < Quickshell.screens.length; i++) {
@@ -689,6 +701,15 @@ PanelWindow {
                     if (root.selW > 10 && root.selH > 10) {
                         root.hasSelection = true;
                         root.saveCache();
+                        // Fresh mouse selection -> capture right away on release
+                        // instead of waiting for the toolbar shutter button.
+                        // interactionMode === 1 means drawing a new rectangle (not
+                        // moving/resizing an existing one), and video mode stays
+                        // manual because the audio source is still to be picked.
+                        if (root.captureOnRelease && root.interactionMode === 1 && !root.isVideoMode) {
+                            root.executeCapture(false, false);
+                            return;
+                        }
                     } else if (root.interactionMode === 1) {
                         let clamp = (val, min, max) => Math.max(min, Math.min(max, val));
                         let left = clamp(root.startX - 20, 0, Math.max(0, root.width - 40));


### PR DESCRIPTION
Drawing a region and then still having to click the shutter button is two
gestures for one intent. Add general.screenshotCaptureOnRelease (default
false) and a toggle for it in the General tab.

When enabled, releasing the mouse fires executeCapture() only for a freshly
drawn rectangle (interactionMode === 1), never when moving or resizing an
existing selection, and never in video mode, where the audio source is still
to be picked.

Off by default, so nothing changes for existing users.
<img width="932" height="66" alt="image" src="https://github.com/user-attachments/assets/d06c6235-15dd-443f-b11a-cc5a4d98a4f3" />
