### PR TITLE
feat: add network speed monitor

### DIFF
--- a/src/quickshell/bar/TopBar.qml
+++ b/src/quickshell/bar/TopBar.qml
@@ -65,7 +65,7 @@ Item {
     property var defaultModuleSettings: {
         "left": ["left", "workspaces", "focus"],
         "center": ["timedate", "info", "weather", "media", "vis"],
-        "right": ["tray", "sysmon", "kb", "wifi", "bt", "vol", "bat"]
+        "right": ["tray", "sysmon", "netspeed", "kb", "wifi", "bt", "vol", "bat"]
     }
 
     function parseModuleSettings(ms) {
@@ -78,13 +78,13 @@ Item {
                 if (Array.isArray(arr[i])) {
                     let group = [];
                     for (let j = 0; j < arr[i].length; j++) {
-                        if (arr[i][j] === "system") group.push("sysmon", "kb", "wifi", "bt", "vol", "bat");
+                        if (arr[i][j] === "system") group.push("sysmon", "netspeed", "kb", "wifi", "bt", "vol", "bat");
                         else group.push(arr[i][j]);
                     }
                     if (group.length === 1) res.push(group[0]);
                     else if (group.length > 1) res.push(group);
                 } else {
-                    if (arr[i] === "system") res.push(["sysmon", "kb", "wifi", "bt", "vol", "bat"]);
+                    if (arr[i] === "system") res.push(["sysmon", "netspeed", "kb", "wifi", "bt", "vol", "bat"]);
                     else res.push(arr[i]);
                 }
             }
@@ -205,6 +205,7 @@ Item {
     property real wVis: isModuleActive("vis") ? (visWidget.targetWidth !== undefined ? visWidget.targetWidth : visWidget.width) : 0
     property real wTray: isModuleActive("tray") ? (trayWidget.targetWidth !== undefined ? trayWidget.targetWidth : trayWidget.width) : 0
     property real wSysmon: isModuleActive("sysmon") ? (sysMonWidget.targetWidth !== undefined ? sysMonWidget.targetWidth : sysMonWidget.width) : 0
+    property real wNetSpeed: isModuleActive("netspeed") ? (netSpeedWidget.targetWidth !== undefined ? netSpeedWidget.targetWidth : netSpeedWidget.width) : 0
     property real wKb: isModuleActive("kb") ? (kbWidget.targetWidth !== undefined ? kbWidget.targetWidth : kbWidget.width) : 0
     property real wWifi: isModuleActive("wifi") ? (wifiWidget.targetWidth !== undefined ? wifiWidget.targetWidth : wifiWidget.width) : 0
     property real wBt: isModuleActive("bt") ? (btWidget.targetWidth !== undefined ? btWidget.targetWidth : btWidget.width) : 0
@@ -222,6 +223,7 @@ Item {
         if (moduleId === "vis") return wVis;
         if (moduleId === "tray") return wTray;
         if (moduleId === "sysmon") return wSysmon;
+        if (moduleId === "netspeed") return wNetSpeed;
         if (moduleId === "kb") return wKb;
         if (moduleId === "wifi") return wWifi;
         if (moduleId === "bt") return wBt;
@@ -412,6 +414,7 @@ Item {
         if (id === "vis") return visWidget;
         if (id === "tray") return trayWidget;
         if (id === "sysmon") return sysMonWidget;
+        if (id === "netspeed") return netSpeedWidget;
         if (id === "kb") return kbWidget;
         if (id === "wifi") return wifiWidget;
         if (id === "bt") return btWidget;
@@ -827,6 +830,28 @@ Item {
         }
     }
 
+    NetSpeedWidget {
+        id: netSpeedWidget
+        z: 1
+        x: targetX
+        y: barWindow ? barWindow.baseOffsetY : 0
+        visible: contentWrapper.isModuleActive("netspeed")
+        barWindow: contentWrapper.barWindow
+        isSolid: contentWrapper.isSolid || contentWrapper.isFill
+        moduleActive: contentWrapper.isModuleActive("netspeed")
+        isGrouped: contentWrapper.isModuleGrouped("netspeed")
+        targetX: contentWrapper.getModuleX("netspeed", contentWrapper.layoutState)
+
+        Behavior on opacity {
+            NumberAnimation { duration: 200; easing.type: Easing.OutCubic }
+        }
+
+        Behavior on x {
+            enabled: contentWrapper.layoutAnimationsEnabled
+            NumberAnimation { duration: 300; easing.type: Easing.OutCubic }
+        }
+    }
+
     KbWidget {
         id: kbWidget
         z: 1
@@ -946,7 +971,7 @@ Item {
         property alias batPill: batWidget.batPill
 
         function getBounds() {
-            let pills = [sysMonWidget, kbWidget, wifiWidget, btWidget, volWidget, batWidget];
+            let pills = [sysMonWidget, netSpeedWidget, kbWidget, wifiWidget, btWidget, volWidget, batWidget];
             let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
             let found = false;
             for (let i = 0; i < pills.length; i++) {

--- a/src/quickshell/bar/modules/qmldir
+++ b/src/quickshell/bar/modules/qmldir
@@ -14,3 +14,4 @@ BtWidget 1.0 system/BtWidget.qml
 KbWidget 1.0 system/KbWidget.qml
 VolWidget 1.0 system/VolWidget.qml
 WifiWidget 1.0 system/WifiWidget.qml
+NetSpeedWidget 1.0 system/NetSpeedWidget.qml

--- a/src/quickshell/bar/modules/system/NetSpeedWidget.qml
+++ b/src/quickshell/bar/modules/system/NetSpeedWidget.qml
@@ -1,0 +1,147 @@
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+import "../../../reusables"
+import "../../../"
+
+Rectangle {
+    id: root
+
+    property var barWindow
+    property bool isSolid: false
+    property bool moduleActive: true
+    property bool isGrouped: false
+    property real targetX: 0
+
+    x: targetX
+    y: barWindow ? barWindow.baseOffsetY : 0
+
+    height: barWindow ? barWindow.barHeight : 40
+    width: barWindow ? barWindow.s(180) : 180
+
+    radius: Math.min(
+        ThemeBackend.borderRadius,
+        height / 2
+    )
+
+    color: (isGrouped || isSolid)
+        ? "transparent"
+        : ThemeBackend.base
+
+    border.color: (isGrouped || isSolid)
+        ? "transparent"
+        : ThemeBackend.surface0
+
+    border.width: (isGrouped || isSolid) ? 0 : 1
+
+    visible: moduleActive
+
+    opacity: moduleActive
+        ? ((barWindow && barWindow.barOpacity !== undefined)
+            ? barWindow.barOpacity
+            : 1.0)
+        : 0.0
+
+    function updateSubscription() {
+        if (moduleActive) {
+            SysData.subscribe()
+        } else {
+            SysData.unsubscribe()
+        }
+    }
+
+    Component.onCompleted: updateSubscription()
+    Component.onDestruction: SysData.unsubscribe()
+    onModuleActiveChanged: updateSubscription()
+
+    function formatSpeed(value) {
+        if (value <= 0 || isNaN(value))
+            return "0 B/s"
+
+        let k = 1024
+        let sizes = ["B/s", "KB/s", "MB/s", "GB/s"]
+        let i = Math.floor(Math.log(value) / Math.log(k))
+
+        return parseFloat(
+            (value / Math.pow(k, i)).toFixed(1)
+        ) + " " + sizes[i]
+    }
+
+    Behavior on x {
+        enabled: barWindow && barWindow.startupCascadeFinished
+
+        NumberAnimation {
+            duration: 300
+            easing.type: Easing.OutCubic
+        }
+    }
+
+    Behavior on opacity {
+        NumberAnimation {
+            duration: 140
+            easing.type: Easing.OutCubic
+        }
+    }
+
+    RowLayout {
+        id: netLayout
+
+        anchors.centerIn: parent
+
+        spacing: barWindow ? barWindow.s(6) : 6
+
+        Text {
+            text: "\uF063"
+
+            font.family: ThemeBackend.fontFamily
+            font.pixelSize: barWindow
+                ? barWindow.s(11.55)
+                : 11.55
+
+            color: ThemeBackend.subtext0
+
+            Layout.alignment: Qt.AlignVCenter
+        }
+
+        Text {
+            text: root.formatSpeed(SysData.netRx)
+
+            font.family: ThemeBackend.fontFamily
+            font.pixelSize: barWindow
+                ? barWindow.s(12.6)
+                : 12.6
+
+            font.bold: true
+            color: ThemeBackend.text
+
+            Layout.alignment: Qt.AlignVCenter
+        }
+
+        Text {
+            text: "\uF062"
+
+            font.family: ThemeBackend.fontFamily
+            font.pixelSize: barWindow
+                ? barWindow.s(11.55)
+                : 11.55
+
+            color: ThemeBackend.subtext0
+
+            Layout.alignment: Qt.AlignVCenter
+        }
+
+        Text {
+            text: root.formatSpeed(SysData.netTx)
+
+            font.family: ThemeBackend.fontFamily
+            font.pixelSize: barWindow
+                ? barWindow.s(12.6)
+                : 12.6
+
+            font.bold: true
+            color: ThemeBackend.text
+
+            Layout.alignment: Qt.AlignVCenter
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Adds a network speed monitor to the system bar.

## Changes

- Adds download/upload speed display
- Adds dynamic speed units (B/s, KB/s, MB/s, GB/s)
- Integrates the widget into the system bar
- Registers the widget in `qmldir`

## Testing

- Tested with the development build
- Verified live download/upload speed updates