### PR TITLE
fix(current_focus): exit after SIGTERM cleanup instead of resuming loop

### DIFF
--- a/src/scripts/current_focus.sh
+++ b/src/scripts/current_focus.sh
@@ -16,7 +16,9 @@ for pid in $(pgrep -f "$(basename "$0")"); do
 done
 
 cleanup() {
+    trap - EXIT SIGTERM SIGINT
     pkill -P $$ 2>/dev/null
+    exit 0
 }
 trap cleanup EXIT SIGTERM SIGINT
 


### PR DESCRIPTION
## Problem

`current_focus.sh` never exits on SIGTERM. The trap runs `cleanup()` (kill children) and then the script resumes its main loop:

```
while true; do
    while read -r line; do ... done < <(listen_events)
    sleep 1
done
```

When the compositor is gone (session shutdown, compositor crash), `listen_events` (`niri msg --json event-stream`) fails instantly, so the loop spins forever respawning `sleep 1` + the event-stream pipeline. The leftover processes keep the systemd scope alive and are only removed when systemd SIGKILLs everything after the stop timeout (90s by default).

Observed on a real shutdown (niri, serpantinum 2.1.1):

```
systemd[459]: app-niri-serpantinumd-693.scope: Stopping timed out. Killing.
systemd[459]: app-niri-serpantinumd-693.scope: Killing process 7036 (bash) with signal SIGKILL.
systemd[459]: app-niri-serpantinumd-693.scope: Killing process 9224 (sleep) with signal SIGKILL.
```

Reproduced standalone with a dead compositor socket: after SIGTERM the script keeps running indefinitely, respawning `sleep 1` every second; only SIGKILL stops it.

## Fix

Make `cleanup()` exit instead of returning into the loop (clear the traps first so the EXIT trap cannot re-enter it). Same pattern as `watchers/kb_wait.sh`.

## Test plan

- [x] Simulated shutdown (empty XDG_RUNTIME_DIR, no niri socket): unpatched script survives SIGTERM indefinitely and respawns `sleep 1` (new PID each second); patched script exits in ~0.3s
- [x] `bash -n` clean
- [ ] Real session shutdown: scope stops without the 90s timeout
