### PR TITLE
fix: add previous/next media key bindings

### DIFF
--- a/compositors/hyprland/config/keybinds.lua
+++ b/compositors/hyprland/config/keybinds.lua
@@ -37,6 +37,8 @@ hl.bind(mainMod .. " + L", hl.dsp.exec_cmd("serpantinum lock"), { repeating = tr
 hl.bind(mainMod .. " + SPACE", hl.dsp.exec_cmd("playerctl play-pause"), { locked = true })
 hl.bind("XF86AudioPause", hl.dsp.exec_cmd("playerctl play-pause"), { locked = true })
 hl.bind("XF86AudioPlay", hl.dsp.exec_cmd("playerctl play-pause"), { locked = true })
+hl.bind("XF86AudioPrev", hl.dsp.exec_cmd("playerctl previous"), { locked = true })
+hl.bind("XF86AudioNext", hl.dsp.exec_cmd("playerctl next"), { locked = true })
 hl.bind("XF86AudioMicMute", hl.dsp.exec_cmd("serpantinum volume mic-toggle"), { locked = true })
 hl.bind("XF86AudioMute", hl.dsp.exec_cmd("serpantinum volume mute-toggle"), { locked = true })
 hl.bind("XF86AudioLowerVolume", hl.dsp.exec_cmd("serpantinum volume lower"), { repeating = true, locked = true })

--- a/compositors/niri/config/keybinds.kdl
+++ b/compositors/niri/config/keybinds.kdl
@@ -20,6 +20,8 @@ binds {
     Mod+Space { spawn "playerctl" "play-pause"; }
     XF86AudioPause { spawn "playerctl" "play-pause"; }
     XF86AudioPlay { spawn "playerctl" "play-pause"; }
+    XF86AudioPrev { spawn "playerctl" "previous"; }
+    XF86AudioNext { spawn "playerctl" "next"; }
     XF86AudioMicMute { spawn "serpantinum" "volume" "mic-toggle"; }
     XF86AudioMute { spawn "serpantinum" "volume" "mute-toggle"; }
     XF86AudioLowerVolume { spawn "serpantinum" "volume" "lower"; }

--- a/compositors/sway/configDir/keybinds
+++ b/compositors/sway/configDir/keybinds
@@ -19,6 +19,8 @@ bindsym $mod+L exec serpantinum lock
 bindsym $mod+space exec playerctl play-pause
 bindsym XF86AudioPause exec playerctl play-pause
 bindsym XF86AudioPlay exec playerctl play-pause
+bindsym XF86AudioPrev exec playerctl previous
+bindsym XF86AudioNext exec playerctl next
 bindsym XF86AudioMicMute exec serpantinum volume mic-toggle
 bindsym XF86AudioMute exec serpantinum volume mute-toggle
 bindsym XF86AudioLowerVolume exec serpantinum volume lower


### PR DESCRIPTION
## Summary

Add support for the standard previous and next media keys in the Sway, Hyprland, and Niri compositor configurations.

- `XF86AudioPrev` runs `playerctl previous`
- `XF86AudioNext` runs `playerctl next`

## Testing

Tested on Hyprland with hardware media keys.

- Previous track works as expected
- Next track works as expected