### PR TITLE
fix: keep tray menu open when the bar hides under it

### DIFF
--- a/src/quickshell/bar/modules/TrayWidget.qml
+++ b/src/quickshell/bar/modules/TrayWidget.qml
@@ -79,7 +79,7 @@ Rectangle {
             TrayMenuController.hide();
         }
         function onIsRevealedChanged() {
-            if (barWindow && !barWindow.isRevealed) {
+            if (barWindow && !barWindow.isRevealed && !TrayMenuController.menuHovered) {
                 TrayMenuController.hide();
             }
         }

--- a/src/quickshell/bar/sidemodules/SideTrayWidget.qml
+++ b/src/quickshell/bar/sidemodules/SideTrayWidget.qml
@@ -83,7 +83,7 @@ Rectangle {
             TrayMenuController.hide();
         }
         function onIsRevealedChanged() {
-            if (barWindow && !barWindow.isRevealed) {
+            if (barWindow && !barWindow.isRevealed && !TrayMenuController.menuHovered) {
                 TrayMenuController.hide();
             }
         }


### PR DESCRIPTION
With autohide on, hovering the tray icon reveals the bar and opens the tray menu. Moving the pointer from the icon into the menu makes hover leave the bar window, the autohide timer fires, and the bar hides. Both `src/quickshell/bar/modules/TrayWidget.qml` and `src/quickshell/bar/sidemodules/SideTrayWidget.qml` call `TrayMenuController.hide()` from `onIsRevealedChanged` whenever `!barWindow.isRevealed`, so the menu is dismissed on entry. With autohide on, every tray menu item is unreachable.

Why the bar hides: the menu is a separate popout window, so the bar's hover tracking never covers it; entering the menu always reads as leaving the bar. The fix belongs on the hide side, not in reworked bar hover tracking.

The change guards the bar-hide close with `!TrayMenuController.menuHovered`: skip closing while the menu itself is hovered. `menuHovered` is an existing public property on the `TrayMenuController` singleton (declared in `src/quickshell/singletons/widgetcontrols/TrayMenuController.qml`, set by the popout in `src/quickshell/popouts/TrayBase.qml`). No new state. Other close paths are unchanged: the menu closes via its own `requestHide` when the pointer leaves it, and the bar-hide close still fires when the bar hides for any other reason.

Tested: `patch -p1 --dry-run` applies cleanly to master (`827c2337`). `git apply` rejects the patch — it is hunk-only, without `---`/`+++` headers — so it must be applied with `patch(1)`. The nix build is green and `nix flake check` passes. Live with autohide on: the menu stays open on entry and closes on leave.

Separately, this repo's local config sets `bar.autohide=false` as a workaround; it is unrelated to this patch and not part of it.
