### PR TITLE
Remove duplicate no-op lines in QR polygon parser

### DIFF
--- a/src/scripts/screenshot.sh
+++ b/src/scripts/screenshot.sh
@@ -228,8 +228,6 @@ try:
                                     max_x = max(max_x, x)
                                     min_y = min(min_y, y)
                                     max_y = max(max_y, y)
-                                    min_y = min(min_y, y)
-                                    max_y = max(max_y, y)
                                 except ValueError:
                                     pass
             if min_x == float('inf'): min_x, min_y, max_x, max_y = 0, 0, 0, 0


### PR DESCRIPTION
min_y/max_y were being updated twice in a row in the embedded Python QR-parsing script. Harmless but dead code.

