### PR TITLE
feat: add autohide toggle keybindings

### DIFF
--- a/compositors/hyprland/config/keybinds.lua
+++ b/compositors/hyprland/config/keybinds.lua
@@ -56,6 +56,7 @@ hl.bind(mainMod .. " + S", hl.dsp.exec_cmd("serpantinum msg toggle calendar"))
 hl.bind(mainMod .. " + N", hl.dsp.exec_cmd("serpantinum msg toggle network"))
 hl.bind(mainMod .. " + V", hl.dsp.exec_cmd("serpantinum msg toggle volume"))
 hl.bind(mainMod .. " + H", hl.dsp.exec_cmd("serpantinum msg toggle guide"))
+hl.bind(mainMod .. " + A", hl.dsp.exec_cmd("serpantinum msg toggle autohide"))
 
 for i = 1, 10 do
   local ws = tostring(i)

--- a/compositors/niri/config/keybinds.kdl
+++ b/compositors/niri/config/keybinds.kdl
@@ -35,6 +35,7 @@ binds {
     Mod+N { spawn "serpantinum" "msg" "toggle" "network"; }
     Mod+V { spawn "serpantinum" "msg" "toggle" "volume"; }
     Mod+H { spawn "serpantinum" "msg" "toggle" "guide"; }
+    Mod+A { spawn "serpantinum" "msg" "toggle" "autohide"; }
 
     Mod+Left { focus-column-left; }
     Mod+Right { focus-column-right; }

--- a/compositors/sway/configDir/keybinds
+++ b/compositors/sway/configDir/keybinds
@@ -34,6 +34,7 @@ bindsym $mod+S exec serpantinum msg toggle calendar
 bindsym $mod+N exec serpantinum msg toggle network
 bindsym $mod+V exec serpantinum msg toggle volume
 bindsym $mod+H exec serpantinum msg toggle guide
+bindsym $mod+A exec serpantinum msg toggle autohide
 
 bindsym $mod+Left focus left
 bindsym $mod+Right focus right

--- a/src/quickshell/Main.qml
+++ b/src/quickshell/Main.qml
@@ -122,6 +122,13 @@ PanelWindow {
                 return;
             }
 
+            if (cmd === "autohide" || targetWidget === "autohide") {
+                let bar = Config.getSetting("bar", {});
+                bar.autohide = !bar.autohide;
+                Config.setSetting("bar", bar);
+                return;
+            }
+
             let effectivelyActive = masterWindow.targetActive;
 
             if (cmd === "close") {


### PR DESCRIPTION
## Summary

Add a command to toggle the top-bar autohide setting and bind it to `Super+A` across supported compositors.

- Add `autohide` command handling in QuickShell
- Add `Super+A` binding for Hyprland
- Add `$mod+A` binding for Sway
- Add `Mod+A` binding for Niri

## Testing

Tested the autohide command on the installed Serpantinum setup(Hyprland).

- `serpantinum msg toggle autohide` works
- `serpantinum msg autohide` works
- The `bar.autohide` setting toggles correctly in `settings.json`