### PR TITLE
fix(bar): prevent status bar starting in compact mode on hyprland restart

### DIFF
--- a/bin/serpantinumd
+++ b/bin/serpantinumd
@@ -168,6 +168,7 @@ if [ "$COMMAND" == "stop" ]; then
 
     rm -f "/tmp/serpantinumd.pid" 2>/dev/null
     rm -f "/tmp/serpantinumd.lock" 2>/dev/null
+    [ -n "$QS_RUN_DIR" ] && echo '{"widget":"hidden","screen":""}' > "$QS_RUN_DIR/current_widget" 2>/dev/null
     echo "$(t "daemon.cli.stopped")"
     exit 0
 fi
@@ -283,12 +284,15 @@ if [ "$COMMAND" == "start" ]; then
         exec 9>&- 2>/dev/null
         rm -f "/tmp/serpantinumd.pid" 2>/dev/null
         rm -f "/tmp/serpantinumd.lock" 2>/dev/null
+        [ -n "$QS_RUN_DIR" ] && echo '{"widget":"hidden","screen":""}' > "$QS_RUN_DIR/current_widget" 2>/dev/null
         exit 0
     }
 
     trap cleanup SIGINT SIGTERM SIGHUP EXIT
 
     [ "$VERBOSE" = true ] && echo "$(t "daemon.launching")"
+
+    [ -n "$QS_RUN_DIR" ] && mkdir -p "$QS_RUN_DIR" && echo '{"widget":"hidden","screen":""}' > "$QS_RUN_DIR/current_widget" 2>/dev/null
 
     bash "$SERPANTINUM_DIR/quickshell/guide/wellbeing/launch_daemon.sh" 9>&- &
     LAUNCH_PID=$!

--- a/src/quickshell/Main.qml
+++ b/src/quickshell/Main.qml
@@ -54,8 +54,11 @@ PanelWindow {
     }
 
     function reportWidgetState() {
-        if (!Caching.runDir) return;
         let sName = (masterWindow.currentActive === "hidden" || !masterWindow.screen) ? "" : (masterWindow.screen.name || "");
+        if (typeof PanelController !== "undefined") {
+            PanelController.setActive(masterWindow.currentActive, sName, masterWindow.screen);
+        }
+        if (!Caching.runDir) return;
         let payload = JSON.stringify({
             widget: masterWindow.currentActive,
             screen: sName
@@ -327,6 +330,7 @@ PanelWindow {
     }
 
     Component.onCompleted: {
+        reportWidgetState();
         preloadStaggerTimer.start();
     }
 

--- a/src/quickshell/bar/Bar.qml
+++ b/src/quickshell/bar/Bar.qml
@@ -295,7 +295,21 @@ Variants {
                 }
             }
 
-            property string activeWidget: ""
+            property string externalWidget: ""
+            property string activeWidget: {
+                if (typeof PanelController !== "undefined" && PanelController.activeWidget) {
+                    let w = PanelController.activeWidget;
+                    if (w === "notifications" || w === "system") {
+                        let targetScreen = PanelController.targetScreen;
+                        let myScreenName = (barWindow.screen && barWindow.screen.name) ? barWindow.screen.name : "";
+                        if (!targetScreen || targetScreen === myScreenName) {
+                            return w;
+                        }
+                    }
+                    return "";
+                }
+                return externalWidget;
+            }
             property bool isNotifOpen: activeWidget === "notifications"
             property bool isSysOpen: activeWidget === "system"
 
@@ -336,8 +350,12 @@ Variants {
                         }
                     }
 
-                    if (barWindow.activeWidget !== effectiveWidget) {
-                        barWindow.activeWidget = effectiveWidget;
+                    if (typeof PanelController !== "undefined" && PanelController.activeWidget === "hidden" && effectiveWidget !== "") {
+                        return;
+                    }
+
+                    if (barWindow.externalWidget !== effectiveWidget) {
+                        barWindow.externalWidget = effectiveWidget;
                     }
                 }
             }

--- a/src/quickshell/bar/TopBar.qml
+++ b/src/quickshell/bar/TopBar.qml
@@ -284,6 +284,7 @@ Item {
     property real rawCNaturalX: {
         if (layoutState === "settings") return screenMaxRight - rWidthTarget - crGap - cWidthTarget;
         if (layoutState === "sys") return screenMinLeft + lWidthTarget + lcGap;
+        if (contentWrapper.width <= 0) return 0;
         return (contentWrapper.width - cWidthTarget) / 2;
     }
 
@@ -319,7 +320,7 @@ Item {
     property real rFinalClampedX: Math.max(screenMinLeft, Math.min(screenMaxRight - rWidthTarget, rFinalX))
 
     property real dynamicMinX: {
-        if (isFill) return 0;
+        if (isFill || contentWrapper.width <= 0) return 0;
         let m = contentWrapper.width;
         let hasModules = (lWidthTarget > 0 || cWidthTarget > 0 || rWidthTarget > 0);
         if (lWidthTarget > 0) m = Math.min(m, lFinalX - (barWindow ? barWindow.s(1) : 0) - distinctEdgePadding);
@@ -332,6 +333,7 @@ Item {
     }
 
     property real dynamicMaxX: {
+        if (contentWrapper.width <= 0) return 0;
         if (isFill) return contentWrapper.width;
         let m = 0;
         let hasModules = (lWidthTarget > 0 || cWidthTarget > 0 || rWidthTarget > 0);

--- a/src/quickshell/qmldir
+++ b/src/quickshell/qmldir
@@ -59,3 +59,4 @@ singleton OsdController 1.0 singletons/widgetcontrols/OsdController.qml
 singleton SideMusicController 1.0 singletons/widgetcontrols/SideMusicController.qml
 singleton TrayMenuController 1.0 singletons/widgetcontrols/TrayMenuController.qml
 singleton WidgetSync 1.0 singletons/widgetcontrols/WidgetSync.qml
+singleton PanelController 1.0 singletons/widgetcontrols/PanelController.qml

--- a/src/quickshell/singletons/widgetcontrols/PanelController.qml
+++ b/src/quickshell/singletons/widgetcontrols/PanelController.qml
@@ -1,0 +1,31 @@
+pragma Singleton
+import QtQuick
+import Quickshell
+import "../../"
+
+Item {
+    id: controller
+
+    property string activeWidget: "hidden"
+    property string targetScreen: ""
+    property var activeScreen: null
+
+    property bool isSysOpen: activeWidget === "system"
+    property bool isNotifOpen: activeWidget === "notifications"
+
+    function setActive(widget, screenName, screenObj) {
+        let w = widget || "hidden";
+        controller.activeWidget = w;
+        if (w === "hidden") {
+            controller.targetScreen = "";
+            controller.activeScreen = null;
+        } else {
+            controller.targetScreen = screenName || "";
+            controller.activeScreen = screenObj || null;
+        }
+    }
+
+    function reset() {
+        setActive("hidden", "", null);
+    }
+}

--- a/src/quickshell/syspanel/SystemPanel.qml
+++ b/src/quickshell/syspanel/SystemPanel.qml
@@ -530,8 +530,11 @@ Item {
                                 interval: 150
                                 onTriggered: {
                                     closeSequence.start();
+                                    if (typeof PanelController !== "undefined") {
+                                        PanelController.reset();
+                                    }
                                     Quickshell.execDetached(["bash", Caching.serpantinumDir + "/scripts/system/exit.sh"]);
-                                    Quickshell.execDetached(["sh", "-c", "echo 'close' > " + Caching.runDir + "/widget_state"]);
+                                    Quickshell.execDetached(["sh", "-c", "echo '{\"widget\":\"hidden\",\"screen\":\"\"}' > " + Caching.runDir + "/current_widget"]);
                                 }
                             }
 
@@ -1212,8 +1215,13 @@ Item {
                                         actionCapsule.chargingSoundHandle = -1;
                                     }
                                     let scriptPath = cmd === "lock" ? Caching.serpantinumDir + "/scripts/lock.sh" : Caching.serpantinumDir + "/scripts/system/" + (cmd === "sleep" ? "suspend.sh" : cmd + ".sh");
+                                    if (cmd !== "lock" && typeof PanelController !== "undefined") {
+                                        PanelController.reset();
+                                    }
                                     Quickshell.execDetached(["bash", scriptPath]);
-                                    Quickshell.execDetached(["sh", "-c", "echo 'close' > " + Caching.runDir + "/widget_state"]);
+                                    if (cmd !== "lock") {
+                                        Quickshell.execDetached(["sh", "-c", "echo '{\"widget\":\"hidden\",\"screen\":\"\"}' > " + Caching.runDir + "/current_widget"]);
+                                    }
 
                                     actionCapsule.fillLevel = 0.0;
                                     actionCapsule.triggered = false;

--- a/src/scripts/system/exit.sh
+++ b/src/scripts/system/exit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-rm -f /tmp/serpantinumd.lock /tmp/serpantinumd.pid 2>/dev/null
+rm -f /tmp/serpantinumd.lock /tmp/serpantinumd.pid "${XDG_RUNTIME_DIR:-/tmp}/serpantinum/current_widget" 2>/dev/null
 
 if command -v systemctl &>/dev/null; then
     systemctl --user stop graphical-session.target 2>/dev/null

--- a/src/scripts/system/poweroff.sh
+++ b/src/scripts/system/poweroff.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-rm -f /tmp/serpantinumd.lock /tmp/serpantinumd.pid 2>/dev/null
+rm -f /tmp/serpantinumd.lock /tmp/serpantinumd.pid "${XDG_RUNTIME_DIR:-/tmp}/serpantinum/current_widget" 2>/dev/null
 
 if command -v systemctl &>/dev/null && [ -d /run/systemd/system ]; then
     systemctl poweroff -i && exit 0

--- a/src/scripts/system/reboot.sh
+++ b/src/scripts/system/reboot.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-rm -f /tmp/serpantinumd.lock /tmp/serpantinumd.pid 2>/dev/null
+rm -f /tmp/serpantinumd.lock /tmp/serpantinumd.pid "${XDG_RUNTIME_DIR:-/tmp}/serpantinum/current_widget" 2>/dev/null
 
 if command -v systemctl &>/dev/null && [ -d /run/systemd/system ]; then
     systemctl reboot && exit 0


### PR DESCRIPTION
### Summary

Fixes an issue where the status bar unexpectedly launches in compact mode (modules collapsed toward the left) upon Hyprland restarts, even when though system menu / right sidebar is closed.

### Root Cause

The active widget state file (`/run/user/$UID/serpantinum/current_widget`) persists across compositor restarts. On startup, `Bar.qml` reads the stale file before the UI finishes initializing, causing it to apply the `"sys"` compact layout erroneously.

### Solution

- **In-memory state management:** Introduced `PanelController.qml` singleton to manage panel state in memory, ensuring active widget state always initializes to `"hidden"` on startup regardless of runtime file state.
- **Bar binding:** Bound `Bar.qml` active widget state to `PanelController` with staleness guards.
- **Runtime cleanup:** Updated `serpantinumd` and shutdown scripts (`exit.sh`, `reboot.sh`, `poweroff.sh`) to clean up `/run/user/$UID/serpantinum/current_widget` on startup, exit, and shutdown.
- **Geometry guards:** Added width guards in `TopBar.qml` to ensure stable geometry during early surface initialization.
