### PR TITLE
fix: make brightness watcher a singleton to stop leaking inotifywait processes

### DIFF
--- a/src/scripts/brightness.sh
+++ b/src/scripts/brightness.sh
@@ -145,15 +145,34 @@ adjust_brightness() {
     fi
 }
 
+WATCH_PIDFILE="$QS_RUN_DIR/brightness-watch.pid"
+
 watch_brightness() {
     local path
     local paths=("$BRIGHTNESS_STATE")
+
+    mkdir -p "$QS_RUN_DIR" 2>/dev/null || true
+    # Singleton: a shell reload orphans the previous watcher (quickshell
+    # only tracks its direct child), so stop it before starting a new one.
+    # Otherwise every reload leaks a bash+inotifywait pair (see #261).
+    if [[ -f "$WATCH_PIDFILE" ]]; then
+        local old_pid
+        old_pid="$(cat "$WATCH_PIDFILE" 2>/dev/null || true)"
+        if [[ "$old_pid" =~ ^[0-9]+$ ]] && [[ "$old_pid" != "$$" ]]; then
+            if tr '\0' ' ' < "/proc/$old_pid/cmdline" 2>/dev/null | grep -q "brightness.sh"; then
+                kill "$old_pid" 2>/dev/null || true
+                pkill -P "$old_pid" 2>/dev/null || true
+            fi
+        fi
+    fi
+    printf '%s\n' "$$" > "$WATCH_PIDFILE"
+    trap 'rm -f "$WATCH_PIDFILE"' EXIT
 
     touch "$BRIGHTNESS_STATE"
     for path in /sys/class/backlight/*/brightness; do
         [[ -e "$path" ]] && paths+=("$path")
     done
-    inotifywait -m -e modify "${paths[@]}" 2>/dev/null
+    exec inotifywait -m -e modify "${paths[@]}" 2>/dev/null
 }
 
 case "$ACTION" in


### PR DESCRIPTION
Fixes #261.

Root cause: `OsdController.qml` spawns `brightness.sh watch` via Quickshell `Process`. On every shell reload the previous watcher is orphaned (only the direct child is tracked), leaking one bash+inotifywait pair per reload. I reproduced this locally: 6 stale brightness watchers after a few reloads; on setups that reload often this grows into the thousands reported in #261.

Fix: the watcher records its PID in `$QS_RUN_DIR/brightness-watch.pid` and stops any stale predecessor (cmdline-verified as brightness.sh, plus its children) before `exec`ing inotifywait.

Verified: 3 consecutive `serpantinum reload` keep exactly 1 brightness watcher, and `serpantinum brightness raise/lower` still update state (OSD path intact).