### PR TITLE
feat: add game mode for Hyprland (disable animations, blur, shadows)

### DIFF
--- a/bin/serpantinum
+++ b/bin/serpantinum
@@ -113,6 +113,7 @@ show_help() {
     echo "  monitors_detect              $(t "cli.scripts.monitors_detect")"
     echo "  location_manual              $(t "cli.scripts.location_manual")"
     echo "  blue_light_filter            $(t "cli.scripts.blue_light_filter")"
+    echo "  gamemode                     $(t "cli.scripts.gamemode")"
     echo ""
     echo "$(t "cli.options")"
     echo "  -v, --verbose                $(t "cli.verbose_desc")"
@@ -344,6 +345,7 @@ ALLOWED_SCRIPTS=(
     "monitors_detect"
     "location_manual"
     "blue_light_filter"
+    "gamemode"
 )
 
 COMMAND="$1"

--- a/compositors/hyprland/config/keybinds.lua
+++ b/compositors/hyprland/config/keybinds.lua
@@ -58,6 +58,7 @@ hl.bind(mainMod .. " + S", hl.dsp.exec_cmd("serpantinum msg toggle calendar"))
 hl.bind(mainMod .. " + N", hl.dsp.exec_cmd("serpantinum msg toggle network"))
 hl.bind(mainMod .. " + V", hl.dsp.exec_cmd("serpantinum msg toggle volume"))
 hl.bind(mainMod .. " + H", hl.dsp.exec_cmd("serpantinum msg toggle guide"))
+hl.bind(mainMod .. " + G", hl.dsp.exec_cmd("serpantinum gamemode toggle"))
 hl.bind(mainMod .. " + A", hl.dsp.exec_cmd("serpantinum msg toggle autohide"))
 
 for i = 1, 10 do

--- a/compositors/niri/config/keybinds.kdl
+++ b/compositors/niri/config/keybinds.kdl
@@ -37,6 +37,7 @@ binds {
     Mod+N { spawn "serpantinum" "msg" "toggle" "network"; }
     Mod+V { spawn "serpantinum" "msg" "toggle" "volume"; }
     Mod+H { spawn "serpantinum" "msg" "toggle" "guide"; }
+    Mod+G { spawn "serpantinum" "gamemode" "toggle"; }
     Mod+A { spawn "serpantinum" "msg" "toggle" "autohide"; }
 
     Mod+Left { focus-column-left; }

--- a/compositors/sway/configDir/keybinds
+++ b/compositors/sway/configDir/keybinds
@@ -36,6 +36,7 @@ bindsym $mod+S exec serpantinum msg toggle calendar
 bindsym $mod+N exec serpantinum msg toggle network
 bindsym $mod+V exec serpantinum msg toggle volume
 bindsym $mod+H exec serpantinum msg toggle guide
+bindsym $mod+G exec serpantinum gamemode toggle
 bindsym $mod+A exec serpantinum msg toggle autohide
 
 bindsym $mod+Left focus left

--- a/src/assets/languages/en.json
+++ b/src/assets/languages/en.json
@@ -1042,7 +1042,8 @@
       "monitors_detect": "Query active display outputs and refresh rates",
       "location_manual": "Set geographic coordinates and timezone manually",
       "blue_light_filter": "Adjust color temperature and automatic day/night schedule",
-      "translate": "Instant text and selection translator"
+      "translate": "Instant text and selection translator",
+      "gamemode": "Toggle performance mode for gaming (disables animations, blur, shadows)"
     }
   },
   "daemon": {
@@ -1175,5 +1176,18 @@
   },
   "datetime": {
     "full_date": "dddd, MMMM dd"
+  },
+  "gamemode": {
+    "error_hyprland_only": "Error: game mode is only supported on Hyprland.",
+    "already_on": "Game mode is already on.",
+    "already_off": "Game mode is already off.",
+    "on_title": "Game mode on",
+    "on_body": "Animations, blur and shadows disabled for maximum performance.",
+    "off_title": "Game mode off",
+    "off_body": "Desktop effects restored.",
+    "status_on": "Game mode is on.",
+    "status_off": "Game mode is off.",
+    "help": "Usage: serpantinum gamemode [toggle|on|off|status]",
+    "error_unknown_arg": "Error: unknown argument '{ARG}'. Use toggle, on, off or status."
   }
 }

--- a/src/scripts/gamemode.sh
+++ b/src/scripts/gamemode.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# Game mode: disable costly eye-candy (animations, blur, shadows) on Hyprland
+# for maximum performance while gaming. Previous values are saved and
+# restored when game mode is turned off.
+
+source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/caching.sh"
+source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/i18n.sh"
+
+STATE_FILE="$QS_RUN_DIR/gamemode.state"
+
+# option -> performance value applied while game mode is on
+GAME_OPTS=(
+    "animations:enabled=false"
+    "decoration:blur:enabled=false"
+    "decoration:shadow:enabled=false"
+)
+
+GAME_PARSER=""
+
+notify() {
+    command -v notify-send >/dev/null 2>&1 || return 0
+    notify-send -a "Serpantinum" "$1" "$2" 2>/dev/null || true
+}
+
+need_hyprland() {
+    if ! command -v hyprctl >/dev/null 2>&1 || [[ -z "${HYPRLAND_INSTANCE_SIGNATURE:-}" ]]; then
+        echo "$(t "gamemode.error_hyprland_only")" >&2
+        exit 1
+    fi
+}
+
+# Hyprland >= 0.56 uses the Lua config parser where `hyprctl keyword`
+# no longer works and `hyprctl eval 'hl.config({...})'` is required.
+use_eval() {
+    if [[ "$GAME_PARSER" == "eval" ]]; then return 0; fi
+    if [[ "$GAME_PARSER" == "keyword" ]]; then return 1; fi
+    if hyprctl eval 'hl.config({})' >/dev/null 2>&1; then
+        GAME_PARSER="eval"
+        return 0
+    fi
+    GAME_PARSER="keyword"
+    return 1
+}
+
+get_opt() {
+    hyprctl getoption "$1" 2>/dev/null | awk '/^(int|float|str|bool|vec):/ {print $2; exit}'
+}
+
+# "a:b:c" + value -> Lua fragment: a = { b = { c = value } }
+lua_set() {
+    local name="$1" value="$2"
+    local IFS=':'
+    local -a parts=($name)
+    local out="$value" i
+    for (( i=${#parts[@]}-1; i>=0; i-- )); do
+        if (( i == ${#parts[@]}-1 )); then
+            out="${parts[$i]} = $out"
+        else
+            out="${parts[$i]} = { $out }"
+        fi
+    done
+    printf '%s' "$out"
+}
+
+apply_opt() {
+    local name="$1" value="$2"
+    if use_eval; then
+        hyprctl eval "hl.config({ $(lua_set "$name" "$value") })" >/dev/null 2>&1 || true
+    else
+        hyprctl keyword "$name" "$value" >/dev/null 2>&1 || true
+    fi
+}
+
+is_active() { [[ -f "$STATE_FILE" ]]; }
+
+game_on() {
+    need_hyprland
+    if is_active; then echo "$(t "gamemode.already_on")"; return 0; fi
+
+    mkdir -p "$QS_RUN_DIR" 2>/dev/null || true
+    : > "$STATE_FILE"
+    local entry name value
+    for entry in "${GAME_OPTS[@]}"; do
+        name="${entry%%=*}"
+        value="$(get_opt "$name")"
+        printf '%s=%s\n' "$name" "$value" >> "$STATE_FILE"
+        apply_opt "$name" "${entry#*=}"
+    done
+    notify "$(t "gamemode.on_title")" "$(t "gamemode.on_body")"
+    echo "$(t "gamemode.on_title")"
+}
+
+game_off() {
+    need_hyprland
+    if ! is_active; then echo "$(t "gamemode.already_off")"; return 0; fi
+
+    local line name value
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        name="${line%%=*}"
+        value="${line#*=}"
+        if [[ -n "$name" && -n "$value" ]]; then
+            apply_opt "$name" "$value"
+        fi
+    done < "$STATE_FILE"
+    rm -f "$STATE_FILE"
+    notify "$(t "gamemode.off_title")" "$(t "gamemode.off_body")"
+    echo "$(t "gamemode.off_title")"
+}
+
+case "${1:-toggle}" in
+    on) game_on ;;
+    off) game_off ;;
+    status)
+        if is_active; then echo "$(t "gamemode.status_on")"; else echo "$(t "gamemode.status_off")"; fi
+        ;;
+    toggle)
+        if is_active; then game_off; else game_on; fi
+        ;;
+    -h|--help|help) echo "$(t "gamemode.help")" ;;
+    *)
+        echo "$(t "gamemode.error_unknown_arg" "ARG=$1")" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Adds `serpantinum gamemode [toggle|on|off|status]` plus Super+G keybinds on Hyprland, Niri and Sway.

- Saves current eye-candy values (`animations:enabled`, `decoration:blur:enabled`, `decoration:shadow:enabled`) to `$QS_RUN_DIR/gamemode.state` and restores them on exit; toggle is idempotent, `status` reports state
- Supports both Hyprland config parsers: `hyprctl eval hl.config()` on >= 0.56 (where `keyword` errors with "can't work with non-legacy parsers") with automatic fallback to `keyword` on older versions
- Desktop notification on toggle; all user-facing strings via i18n (en keys added: `gamemode.*`, `cli.scripts.gamemode`)
- On Niri/Sway the script reports Hyprland-only instead of failing silently

Tested on Hyprland 0.56.2: full on/off/toggle/status cycle verified via `hyprctl getoption`, previous values restored exactly.