### PR TITLE
feat: minimize windows to the dock (macOS-style) with restore

### DIFF
--- a/bin/serpantinum
+++ b/bin/serpantinum
@@ -113,6 +113,7 @@ show_help() {
     echo "  monitors_detect              $(t "cli.scripts.monitors_detect")"
     echo "  location_manual              $(t "cli.scripts.location_manual")"
     echo "  blue_light_filter            $(t "cli.scripts.blue_light_filter")"
+    echo "  minimize                     $(t "cli.scripts.minimize")"
     echo ""
     echo "$(t "cli.options")"
     echo "  -v, --verbose                $(t "cli.verbose_desc")"
@@ -344,6 +345,7 @@ ALLOWED_SCRIPTS=(
     "monitors_detect"
     "location_manual"
     "blue_light_filter"
+    "minimize"
 )
 
 COMMAND="$1"

--- a/compositors/hyprland/config/keybinds.lua
+++ b/compositors/hyprland/config/keybinds.lua
@@ -58,6 +58,7 @@ hl.bind(mainMod .. " + S", hl.dsp.exec_cmd("serpantinum msg toggle calendar"))
 hl.bind(mainMod .. " + N", hl.dsp.exec_cmd("serpantinum msg toggle network"))
 hl.bind(mainMod .. " + V", hl.dsp.exec_cmd("serpantinum msg toggle volume"))
 hl.bind(mainMod .. " + H", hl.dsp.exec_cmd("serpantinum msg toggle guide"))
+hl.bind(mainMod .. " + SHIFT + M", hl.dsp.exec_cmd("serpantinum minimize"))
 hl.bind(mainMod .. " + A", hl.dsp.exec_cmd("serpantinum msg toggle autohide"))
 
 for i = 1, 10 do

--- a/src/assets/languages/en.json
+++ b/src/assets/languages/en.json
@@ -1042,7 +1042,8 @@
       "monitors_detect": "Query active display outputs and refresh rates",
       "location_manual": "Set geographic coordinates and timezone manually",
       "blue_light_filter": "Adjust color temperature and automatic day/night schedule",
-      "translate": "Instant text and selection translator"
+      "translate": "Instant text and selection translator",
+      "minimize": "Minimize windows to the dock (special workspace) and restore them"
     }
   },
   "daemon": {
@@ -1175,5 +1176,14 @@
   },
   "datetime": {
     "full_date": "dddd, MMMM dd"
+  },
+  "minimize": {
+    "error_hyprland_only": "Error: minimize is only supported on Hyprland.",
+    "error_no_window": "Error: no active window to minimize.",
+    "error_no_address": "Error: no window address given to restore.",
+    "minimized_title": "Window minimized",
+    "restored_title": "Window restored",
+    "help": "Usage: serpantinum minimize [[address]|restore <address>|list]",
+    "error_unknown_arg": "Error: unknown argument '{ARG}'."
   }
 }

--- a/src/quickshell/dock/Dock.qml
+++ b/src/quickshell/dock/Dock.qml
@@ -3,6 +3,7 @@ import QtQuick.Layouts
 import QtQuick.Controls
 import QtQuick.Shapes
 import Quickshell
+import Quickshell.Io
 import Quickshell.Wayland
 import Quickshell.Hyprland
 import "../"
@@ -1605,6 +1606,127 @@ Variants {
                                                 }
                                                 dockWindow.launchApp(model.desktop_id);
                                             }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Item {
+                    id: minimizedStrip
+                    visible: minimizedAppsModel.count > 0 && dockWindow.initialized && !dockWindow.editMode && !dockWindow.isFullscreenActive
+
+                    property real stripGap: dockWindow.s(8)
+                    property real btnSize: dockWindow.s(Math.max(24, Math.round(dockWindow.dockElementSize * 0.72)))
+                    property real stripPad: dockWindow.s(6)
+
+                    width: dockWindow.isVertical ? (btnSize + stripPad * 2) : (minimizedAppsModel.count * (btnSize + dockWindow.s(6)) - dockWindow.s(6) + stripPad * 2)
+                    height: dockWindow.isVertical ? (minimizedAppsModel.count * (btnSize + dockWindow.s(6)) - dockWindow.s(6) + stripPad * 2) : (btnSize + stripPad * 2)
+
+                    x: {
+                        if (dockWindow.isVertical) {
+                            if (dockWindow.dockPosition === "left") return dockContainer.x + dockTransform.x + dockContainer.width + stripGap;
+                            return dockContainer.x + dockTransform.x - width - stripGap;
+                        }
+                        return Math.round(dockContainer.x + dockTransform.x + (dockContainer.width - width) / 2);
+                    }
+                    y: {
+                        if (!dockWindow.isVertical) {
+                            if (dockWindow.dockPosition === "bottom") return dockContainer.y + dockTransform.y - height - stripGap;
+                            return dockContainer.y + dockTransform.y + dockContainer.height + stripGap;
+                        }
+                        return Math.round(dockContainer.y + dockTransform.y + (dockContainer.height - height) / 2);
+                    }
+
+                    ListModel { id: minimizedAppsModel }
+
+                    function loadMinimized() {
+                        let arr = [];
+                        try { arr = JSON.parse(minimizedStateFile.text()); } catch (e) { arr = []; }
+                        if (!Array.isArray(arr)) arr = [];
+                        minimizedAppsModel.clear();
+                        for (let i = 0; i < arr.length; i++) {
+                            let it = arr[i] || {};
+                            minimizedAppsModel.append({
+                                address: it.address || "",
+                                cls: it.class || "",
+                                title: it.title || ""
+                            });
+                        }
+                    }
+
+                    FileView {
+                        id: minimizedStateFile
+                        path: Caching.runDir + "/minimized.json"
+                        watchChanges: true
+                        onLoaded: minimizedStrip.loadMinimized()
+                        onFileChanged: minimizedStrip.loadMinimized()
+                    }
+
+                    Rectangle {
+                        anchors.fill: parent
+                        radius: Math.min(ThemeBackend.borderRadius, minimizedStrip.btnSize * 0.3)
+                        color: Qt.alpha(ThemeBackend.base, 0.85)
+                        border.color: ThemeBackend.surface1
+                        border.width: 1
+                    }
+
+                    GridLayout {
+                        anchors.fill: parent
+                        anchors.margins: minimizedStrip.stripPad
+                        columns: dockWindow.isVertical ? 1 : Math.max(1, minimizedAppsModel.count)
+                        rows: dockWindow.isVertical ? Math.max(1, minimizedAppsModel.count) : 1
+                        columnSpacing: dockWindow.s(6)
+                        rowSpacing: dockWindow.s(6)
+
+                        Repeater {
+                            model: minimizedAppsModel
+
+                            delegate: Rectangle {
+                                implicitWidth: minimizedStrip.btnSize
+                                implicitHeight: minimizedStrip.btnSize
+                                Layout.preferredWidth: minimizedStrip.btnSize
+                                Layout.preferredHeight: minimizedStrip.btnSize
+                                radius: Math.round(minimizedStrip.btnSize * 0.28)
+                                color: minBtnMa.containsMouse ? Qt.lighter(ThemeBackend.surface0, 1.12) : ThemeBackend.surface0
+                                border.color: ThemeBackend.surface1
+                                border.width: 1
+                                clip: true
+
+                                property string iconName: (model.cls || "").toLowerCase()
+
+                                Image {
+                                    id: minAppIcon
+                                    anchors.fill: parent
+                                    anchors.margins: minimizedStrip.stripPad
+                                    fillMode: Image.PreserveAspectFit
+                                    asynchronous: true
+                                    smooth: true
+                                    mipmap: true
+                                    visible: status === Image.Ready
+                                    source: parent.iconName !== "" ? "image://icon/" + parent.iconName : ""
+                                }
+
+                                Text {
+                                    anchors.centerIn: parent
+                                    visible: minAppIcon.status === Image.Error || parent.iconName === ""
+                                    text: (model.title || "?").charAt(0).toUpperCase()
+                                    font.family: ThemeBackend.fontFamily
+                                    font.pixelSize: Math.round(minimizedStrip.btnSize * 0.42)
+                                    font.weight: Font.Bold
+                                    color: ThemeBackend.text
+                                }
+
+                                MouseArea {
+                                    id: minBtnMa
+                                    anchors.fill: parent
+                                    cursorShape: Qt.PointingHandCursor
+                                    hoverEnabled: true
+                                    onClicked: {
+                                        if (model.address !== "") {
+                                            Quickshell.execDetached(["bash", Caching.serpantinumDir + "/scripts/minimize.sh", "restore", model.address]);
                                         }
                                     }
                                 }

--- a/src/scripts/minimize.sh
+++ b/src/scripts/minimize.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# Minimize windows to the "minimized" special workspace on Hyprland
+# (macOS-style minimize-to-dock) and restore them on demand.
+#
+# State is tracked in $QS_RUN_DIR/minimized.json so the dock can list
+# minimized windows with icons and restore them on click.
+
+source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/caching.sh"
+source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/i18n.sh"
+
+STATE_FILE="$QS_RUN_DIR/minimized.json"
+SPECIAL_WS="special:minimized"
+
+need_hyprland() {
+    if ! command -v hyprctl >/dev/null 2>&1 || [[ -z "${HYPRLAND_INSTANCE_SIGNATURE:-}" ]]; then
+        echo "$(t "minimize.error_hyprland_only")" >&2
+        exit 1
+    fi
+}
+
+notify() {
+    command -v notify-send >/dev/null 2>&1 || return 0
+    notify-send -a "Serpantinum" "$1" 2>/dev/null || true
+}
+
+# hypr_eval <lua-body> : run hl.dispatch(...) via eval (required on the
+# Lua config parser where classic `hyprctl dispatch args` is unavailable).
+hypr_eval() {
+    hyprctl eval "$1" >/dev/null 2>&1
+}
+
+load_state() {
+    [[ -f "$STATE_FILE" ]] && cat "$STATE_FILE" 2>/dev/null || echo "[]"
+}
+
+save_state() {
+    mkdir -p "$QS_RUN_DIR" 2>/dev/null || true
+    printf '%s\n' "$1" > "$STATE_FILE"
+}
+
+# Drop entries whose windows no longer exist.
+prune_state() {
+    local state addrs addr
+    state="$(load_state)"
+    addrs="$(hyprctl clients -j 2>/dev/null | jq -r '.[].address' 2>/dev/null)"
+    state="$(printf '%s' "$state" | jq --argjson keep "$(printf '%s' "$addrs" | jq -R . | jq -s .)" \
+        'map(select(.address as $a | $keep | index($a)))' 2>/dev/null || echo "[]")"
+    save_state "$state"
+    printf '%s' "$state"
+}
+
+active_address() {
+    hyprctl activewindow -j 2>/dev/null | jq -r '.address // empty' 2>/dev/null
+}
+
+focused_workspace_id() {
+    hyprctl activeworkspace -j 2>/dev/null | jq -r '.id // empty' 2>/dev/null
+}
+
+cmd_minimize() {
+    need_hyprland
+    local addr="${1:-}"
+    [[ -z "$addr" ]] && addr="$(active_address)"
+    if [[ -z "$addr" ]]; then
+        echo "$(t "minimize.error_no_window")" >&2
+        exit 1
+    fi
+    local info cls title floating
+    info="$(hyprctl clients -j 2>/dev/null | jq -r --arg a "$addr" '.[] | select(.address == $a) | "\(.class)|\(.title)|\(.floating)"' 2>/dev/null | head -n 1)"
+    cls="${info%%|*}"
+    title="$(printf '%s' "${info#*|}" | cut -d'|' -f1)"
+    floating="$(printf '%s' "$info" | awk -F'|' '{print $NF}')"
+    # Float first so the tiling layout doesn't reflow when the window leaves
+    # (macOS-like behavior); original state is restored on unminimize.
+    local was_floating="true"
+    if [[ "$floating" != "true" ]]; then
+        was_floating="false"
+        hypr_eval "hl.dispatch(hl.dsp.window.float({ action = \"set\", window = \"address:$addr\" }))"
+    fi
+    hypr_eval "hl.dispatch(hl.dsp.window.move({ workspace = \"$SPECIAL_WS\", window = \"address:$addr\" }))"
+    local state
+    state="$(prune_state)"
+    state="$(printf '%s' "$state" | jq --arg a "$addr" --arg c "$cls" --arg t "$title" --argjson f "$was_floating" \
+        'map(select(.address != $a)) + [{address: $a, class: $c, title: $t, floating: $f}]' 2>/dev/null)"
+    save_state "$state"
+    notify "$(t "minimize.minimized_title")"
+    echo "$(t "minimize.minimized_title")"
+}
+
+cmd_restore() {
+    need_hyprland
+    local addr="${1:-}"
+    if [[ -z "$addr" ]]; then
+        echo "$(t "minimize.error_no_address")" >&2
+        exit 1
+    fi
+    local ws
+    ws="$(focused_workspace_id)"
+    [[ -z "$ws" ]] && ws="1"
+    hypr_eval "hl.dispatch(hl.dsp.window.move({ workspace = $ws, window = \"address:$addr\" }))"
+    hypr_eval "hl.dispatch(hl.dsp.focus({ window = \"address:$addr\" }))"
+    local state was_floating
+    state="$(prune_state)"
+    was_floating="$(printf '%s' "$state" | jq -r --arg a "$addr" '.[] | select(.address == $a) | .floating // true' 2>/dev/null | head -n 1)"
+    if [[ "$was_floating" == "false" ]]; then
+        # small delay: unsetting float in the same tick as leaving the
+        # special workspace is silently dropped by the compositor
+        sleep 0.5
+        hypr_eval "hl.dispatch(hl.dsp.window.float({ action = \"unset\", window = \"address:$addr\" }))"
+    fi
+    state="$(printf '%s' "$state" | jq --arg a "$addr" 'map(select(.address != $a))' 2>/dev/null || echo "[]")"
+    save_state "$state"
+    echo "$(t "minimize.restored_title")"
+}
+
+cmd_list() {
+    need_hyprland
+    prune_state | jq -r '.[] | "\(.address)|\(.class)|\(.title)"' 2>/dev/null
+}
+
+case "${1:-}" in
+    ""|minimize) cmd_minimize "${2:-}" ;;
+    0x*) cmd_minimize "$1" ;;
+    restore) cmd_restore "${2:-}" ;;
+    list) cmd_list ;;
+    -h|--help|help) echo "$(t "minimize.help")" ;;
+    *)
+        echo "$(t "minimize.error_unknown_arg" "ARG=$1")" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Adds `serpantinum minimize [[address]|restore <address>|list]` plus a Super+Shift+M keybind (Hyprland-only) and a minimized-windows strip attached to the dock.

- Minimized windows move to the `special:minimized` workspace and show as icons in a strip next to the dock (all 4 dock positions supported); click restores and focuses the window
- Windows are floated before minimizing so the tiling layout doesn't reflow (macOS behavior); the original float state is saved per window and restored on unminimize. Note: unsetting float in the same tick as leaving the special workspace is silently dropped by the compositor, hence a 0.5s delay before untiling
- State lives in `$QS_RUN_DIR/minimized.json` (auto-pruned); the dock watches the file and updates live
- Commands go through `hl.dispatch(hl.dsp...)` eval because classic `hyprctl dispatch args` no longer parses on the Lua config parser (>= 0.56)
- All strings via i18n (en keys: `minimize.*`, `cli.scripts.minimize`)

Tested on Hyprland 0.56.2: minimize/list/restore cycle, tiling untouched (neighbor geometry byte-identical), float state round-trips, dock strip appears and restores on click.