### PR TITLE
feat(display): add per-monitor resolution and refresh rate controls

### DIFF
--- a/src/assets/languages/en.json
+++ b/src/assets/languages/en.json
@@ -252,6 +252,10 @@
         "title": "UI scale",
         "desc": "Set the display scale factor for this monitor"
       },
+      "resolution": {
+        "title": "Resolution",
+        "desc": "Set the display resolution for this monitor"
+      },
       "refreshrate": {
         "title": "Refresh rate",
         "desc": "Set the display refresh rate for this monitor"

--- a/src/assets/languages/en.json
+++ b/src/assets/languages/en.json
@@ -252,6 +252,10 @@
         "title": "UI scale",
         "desc": "Set the display scale factor for this monitor"
       },
+      "refreshrate": {
+        "title": "Refresh rate",
+        "desc": "Set the display refresh rate for this monitor"
+      },
       "widgets": {
         "title": "Desktop widgets",
         "desc": "Configure and place widgets for this monitor",

--- a/src/quickshell/guide/display/DisplayMainTab.qml
+++ b/src/quickshell/guide/display/DisplayMainTab.qml
@@ -28,21 +28,13 @@ Item {
     property var displaySettings: JSON.parse(JSON.stringify(Config.getSetting("display", defaultDisplaySettings)))
     property var monitorsList: []
 
-    readonly property string compositor: {
-        let de = (SystemInfo.desktopEnv || "").toLowerCase();
-        if (de.indexOf("niri") !== -1) return "niri";
-        if (de.indexOf("sway") !== -1) return "sway";
-        return "hyprland";
-    }
+    readonly property string compositor: DisplayManager.compositor
 
     property string pendingMonName: ""
     property real pendingMonTemp: 50
 
-    property string pendingMonScaleName: ""
-    property real pendingMonScaleVal: 1.0
-
-    property string pendingMonRateName: ""
-    property var pendingMonRateData: null
+    property string pendingModeName: ""
+    property var pendingModeData: null
 
     readonly property string detectedCity: {
         if (typeof Location !== "undefined" && Location.city && Location.city !== "Unknown") {
@@ -295,6 +287,68 @@ Item {
         return best;
     }
 
+    function buildResolutions(pairs) {
+        let map = {};
+        for (let i = 0; i < pairs.length; i++) {
+            let p = pairs[i];
+            if (!p || !p.width || !p.height || isNaN(p.rate)) continue;
+            let key = p.width + "x" + p.height;
+            if (!map[key]) map[key] = { width: p.width, height: p.height, rates: [] };
+            map[key].rates.push({ rate: p.rate, mode: p.mode });
+        }
+        let out = [];
+        let keys = Object.keys(map);
+        for (let j = 0; j < keys.length; j++) {
+            let res = map[keys[j]];
+            res.rates = displayTabRoot.normalizeRates(res.rates);
+            if (res.rates.length > 0) out.push(res);
+        }
+        out.sort((a, b) => (b.width * b.height - a.width * a.height) || (b.width - a.width));
+        return out;
+    }
+
+    function ratesForResolution(resolutions, width, height) {
+        for (let i = 0; i < resolutions.length; i++) {
+            if (resolutions[i].width === width && resolutions[i].height === height) {
+                return resolutions[i].rates;
+            }
+        }
+        return [];
+    }
+
+    function queueModeApply(monName, data) {
+        if (!monName || !data) return;
+        pendingModeName = monName;
+        pendingModeData = data;
+        modeDebounceTimer.restart();
+    }
+
+    function persistMode(monName, data) {
+        if (!monName || !data) return;
+        let current = Config.getSetting("display", defaultDisplaySettings);
+        if (!current.monitors) current.monitors = {};
+        if (!current.monitors[monName]) current.monitors[monName] = {};
+        let m = current.monitors[monName];
+        if (data.mode !== undefined && data.mode !== "") m.mode = data.mode;
+        if (data.resolution !== undefined) m.resolution = data.resolution;
+        if (data.rate !== undefined && data.rate !== null) m.refreshRate = data.rate;
+        if (data.scale !== undefined && data.scale !== null) m.scale = data.scale;
+        Config.setSetting("display", current);
+        displayTabRoot.displaySettings = JSON.parse(JSON.stringify(current));
+    }
+
+    function flushModeApply(monName) {
+        modeDebounceTimer.stop();
+        if (pendingModeName === monName && pendingModeData) {
+            let name = pendingModeName;
+            let data = pendingModeData;
+            pendingModeName = "";
+            pendingModeData = null;
+            DisplayManager.applyMode(name, data.mode, data.scale);
+            displayTabRoot.persistMode(name, data);
+        }
+    }
+
     Process {
         id: monitorDetector
         running: false
@@ -327,22 +381,24 @@ Item {
                             let rr = m.refresh_rate ? (m.refresh_rate / 1000) : 60;
                             let sc = item.scale !== undefined ? item.scale : 1.0;
                             let isOff = item.active === false || item.is_active === false || (modes.length > 0 && (item.current_mode === null || item.current_mode === undefined));
-                            let rates = [];
+                            let pairs = [];
                             for (let j = 0; j < modes.length; j++) {
                                 let mo = modes[j];
-                                if (!mo || mo.width !== w || mo.height !== h) continue;
+                                if (!mo || !mo.width || !mo.height) continue;
                                 let rv = (mo.refresh_rate || 60000) / 1000;
-                                rates.push({ rate: rv, mode: w + "x" + h + "@" + displayTabRoot.formatRate(rv) });
+                                pairs.push({ width: mo.width, height: mo.height, rate: rv, mode: mo.width + "x" + mo.height + "@" + displayTabRoot.formatRate(rv) });
                             }
-                            rates = displayTabRoot.normalizeRates(rates);
-                            if (rates.length === 0 && w > 0 && h > 0) {
-                                rates.push({ rate: rr, mode: w + "x" + h + "@" + displayTabRoot.formatRate(rr) });
+                            if (w > 0 && h > 0) {
+                                pairs.push({ width: w, height: h, rate: rr, mode: w + "x" + h + "@" + displayTabRoot.formatRate(rr) });
                             }
+                            let resolutions = displayTabRoot.buildResolutions(pairs);
+                            let rates = displayTabRoot.ratesForResolution(resolutions, w, h);
                             mList.push({
                                 name: k,
                                 dimensions: w + "x" + h,
                                 framerate: Math.round(rr).toString(),
                                 refreshRate: rr,
+                                resolutions: resolutions,
                                 refreshRates: rates,
                                 scale: sc,
                                 active: !isOff
@@ -359,23 +415,25 @@ Item {
                                 let rr = cm.refresh ? (cm.refresh / 1000) : 60;
                                 let sc = item.scale !== undefined ? item.scale : 1.0;
                                 let isOff = item.active === false;
-                                let rates = [];
+                                let pairs = [];
                                 let modes = item.modes || [];
                                 for (let j = 0; j < modes.length; j++) {
                                     let mo = modes[j];
-                                    if (!mo || mo.width !== w || mo.height !== h) continue;
+                                    if (!mo || !mo.width || !mo.height) continue;
                                     let rv = (mo.refresh || 60000) / 1000;
-                                    rates.push({ rate: rv, mode: w + "x" + h + "@" + displayTabRoot.formatRate(rv) + "Hz" });
+                                    pairs.push({ width: mo.width, height: mo.height, rate: rv, mode: mo.width + "x" + mo.height + "@" + displayTabRoot.formatRate(rv) + "Hz" });
                                 }
-                                rates = displayTabRoot.normalizeRates(rates);
-                                if (rates.length === 0 && w > 0 && h > 0) {
-                                    rates.push({ rate: rr, mode: w + "x" + h + "@" + displayTabRoot.formatRate(rr) + "Hz" });
+                                if (w > 0 && h > 0) {
+                                    pairs.push({ width: w, height: h, rate: rr, mode: w + "x" + h + "@" + displayTabRoot.formatRate(rr) + "Hz" });
                                 }
+                                let resolutions = displayTabRoot.buildResolutions(pairs);
+                                let rates = displayTabRoot.ratesForResolution(resolutions, w, h);
                                 mList.push({
                                     name: name,
                                     dimensions: w + "x" + h,
                                     framerate: Math.round(rr).toString(),
                                     refreshRate: rr,
+                                    resolutions: resolutions,
                                     refreshRates: rates,
                                     scale: sc,
                                     active: !isOff
@@ -392,23 +450,24 @@ Item {
                                 let rr = item.refreshRate ? item.refreshRate : 60;
                                 let sc = item.scale !== undefined ? item.scale : 1.0;
                                 let isOff = item.disabled === true;
-                                let rates = [];
+                                let pairs = [];
                                 let modes = item.availableModes || [];
                                 for (let j = 0; j < modes.length; j++) {
                                     let mm = /^(\d+)x(\d+)@([\d.]+)(?:Hz)?$/.exec(modes[j]);
                                     if (!mm) continue;
-                                    if (parseInt(mm[1]) !== w || parseInt(mm[2]) !== h) continue;
-                                    rates.push({ rate: parseFloat(mm[3]), mode: mm[1] + "x" + mm[2] + "@" + mm[3] });
+                                    pairs.push({ width: parseInt(mm[1]), height: parseInt(mm[2]), rate: parseFloat(mm[3]), mode: mm[1] + "x" + mm[2] + "@" + mm[3] });
                                 }
-                                rates = displayTabRoot.normalizeRates(rates);
-                                if (rates.length === 0 && w > 0 && h > 0) {
-                                    rates.push({ rate: rr, mode: w + "x" + h + "@" + displayTabRoot.formatRate(rr) });
+                                if (w > 0 && h > 0) {
+                                    pairs.push({ width: w, height: h, rate: rr, mode: w + "x" + h + "@" + displayTabRoot.formatRate(rr) });
                                 }
+                                let resolutions = displayTabRoot.buildResolutions(pairs);
+                                let rates = displayTabRoot.ratesForResolution(resolutions, w, h);
                                 mList.push({
                                     name: name,
                                     dimensions: w + "x" + h,
                                     framerate: Math.round(rr).toString(),
                                     refreshRate: rr,
+                                    resolutions: resolutions,
                                     refreshRates: rates,
                                     scale: sc,
                                     active: !isOff
@@ -460,59 +519,10 @@ Item {
 
     function applyMonitorPower(monName, enabled) {
         if (!monName) return;
-        if (displayTabRoot.compositor === "niri") {
-            Quickshell.execDetached(["bash", "-c", enabled ? "niri msg output " + monName + " on" : "niri msg output " + monName + " off"]);
-        } else if (displayTabRoot.compositor === "sway") {
-            Quickshell.execDetached(["bash", "-c", "swaymsg output " + monName + (enabled ? " enable" : " disable")]);
-        } else {
-            let mon = displayTabRoot.monitorsList.find(m => m.name === monName);
-            let modeStr = mon ? (mon.dimensions + "@" + mon.framerate) : "preferred";
-            let scaleVal = mon ? mon.scale : 1.0;
-            if (enabled) {
-                let luaCmd =
-                    'hl.monitor({' +
-                    ' output = "' + monName + '",' +
-                    ' mode = "' + modeStr + '",' +
-                    ' position = "auto",' +
-                    ' scale = ' + scaleVal.toString() + ',' +
-                    ' disabled = false' +
-                    ' })';
-                Quickshell.execDetached(["bash", "-c", "hyprctl eval '" + luaCmd + "'"]);
-            } else {
-                let luaCmd =
-                    'hl.monitor({ output = "' + monName + '", disabled = true })';
-                Quickshell.execDetached(["bash", "-c", "hyprctl eval '" + luaCmd + "'"]);
-            }
-        }
-    }
-
-    function applyMonitorScale(monName, scaleVal) {
-        if (!monName || !scaleVal) return;
-        if (displayTabRoot.compositor === "niri") {
-            Quickshell.execDetached(["bash", "-c", "niri msg output " + monName + " scale " + scaleVal.toString()]);
-        } else if (displayTabRoot.compositor === "sway") {
-            Quickshell.execDetached(["bash", "-c", "swaymsg output " + monName + " scale " + scaleVal.toString()]);
-        } else {
-            let mon = displayTabRoot.monitorsList.find(m => m.name === monName);
-            let modeStr = mon ? (mon.dimensions + "@" + mon.framerate) : "preferred";
-            let luaCmd = 'hl.monitor({ output = "' + monName + '", mode = "' + modeStr + '", position = "auto", scale = ' + scaleVal.toString() + ' })';
-            Quickshell.execDetached(["bash", "-c", "hyprctl eval '" + luaCmd + "' || hyprctl keyword monitor " + monName + "," + modeStr + ",auto," + scaleVal.toString()]);
-        }
-    }
-
-    function applyMonitorRefreshRate(monName, rateData) {
-        if (!monName || !rateData || !rateData.mode) return;
-        let modeStr = rateData.mode;
-        if (displayTabRoot.compositor === "niri") {
-            Quickshell.execDetached(["bash", "-c", "niri msg output " + monName + " mode " + modeStr]);
-        } else if (displayTabRoot.compositor === "sway") {
-            Quickshell.execDetached(["bash", "-c", "swaymsg output " + monName + " mode " + modeStr]);
-        } else {
-            let mon = displayTabRoot.monitorsList.find(m => m.name === monName);
-            let scaleVal = mon ? mon.scale : 1.0;
-            let luaCmd = 'hl.monitor({ output = "' + monName + '", mode = "' + modeStr + '", position = "auto", scale = ' + scaleVal.toString() + ' })';
-            Quickshell.execDetached(["bash", "-c", "hyprctl eval '" + luaCmd + "' || hyprctl keyword monitor " + monName + "," + modeStr + ",auto," + scaleVal.toString()]);
-        }
+        let mon = displayTabRoot.monitorsList.find(m => m.name === monName);
+        let modeStr = mon ? (mon.dimensions + "@" + mon.framerate) : "";
+        let scaleVal = mon ? mon.scale : 1.0;
+        DisplayManager.applyPower(monName, enabled, modeStr, scaleVal);
     }
 
     function updateMonitorSettingDebounced(monName, tempVal) {
@@ -548,30 +558,17 @@ Item {
     }
 
     Timer {
-        id: scaleDebounceTimer
+        id: modeDebounceTimer
         interval: 1000
         repeat: false
         onTriggered: {
-            if (displayTabRoot.pendingMonScaleName !== "") {
-                displayTabRoot.applyMonitorScale(displayTabRoot.pendingMonScaleName, displayTabRoot.pendingMonScaleVal);
-                displayTabRoot.updateMonitorSetting(displayTabRoot.pendingMonScaleName, "scale", displayTabRoot.pendingMonScaleVal);
-                displayTabRoot.pendingMonScaleName = "";
-            }
-        }
-    }
-
-    Timer {
-        id: rateDebounceTimer
-        interval: 1000
-        repeat: false
-        onTriggered: {
-            if (displayTabRoot.pendingMonRateName !== "" && displayTabRoot.pendingMonRateData) {
-                let name = displayTabRoot.pendingMonRateName;
-                let data = displayTabRoot.pendingMonRateData;
-                displayTabRoot.applyMonitorRefreshRate(name, data);
-                displayTabRoot.updateMonitorSetting(name, "refreshRate", data.rate);
-                displayTabRoot.pendingMonRateName = "";
-                displayTabRoot.pendingMonRateData = null;
+            if (displayTabRoot.pendingModeName !== "" && displayTabRoot.pendingModeData) {
+                let name = displayTabRoot.pendingModeName;
+                let data = displayTabRoot.pendingModeData;
+                displayTabRoot.pendingModeName = "";
+                displayTabRoot.pendingModeData = null;
+                DisplayManager.applyMode(name, data.mode, data.scale);
+                displayTabRoot.persistMode(name, data);
             }
         }
     }
@@ -698,6 +695,7 @@ Item {
 
                     Component.onCompleted: {
                         appeared = true;
+                        syncResIndexFromModel();
                     }
 
                     property var resDims: modelData.dimensions ? modelData.dimensions.split("x") : ["1920", "1080"]
@@ -712,9 +710,38 @@ Item {
                         return ni >= 0 ? ni : 0;
                     }
 
-                    property var validRates: modelData.refreshRates !== undefined ? modelData.refreshRates : []
+                    property var resList: {
+                        if (modelData.resolutions !== undefined && modelData.resolutions.length > 0) return modelData.resolutions;
+                        if (modelData.dimensions) {
+                            return [{ width: monWidth, height: monHeight, rates: modelData.refreshRates || [] }];
+                        }
+                        return [];
+                    }
+                    readonly property var resOptions: resList.map(function(r) { return r.width + " × " + r.height; })
+                    property int currentResIndex: 0
+                    readonly property var currentRes: (currentResIndex >= 0 && currentResIndex < resList.length) ? resList[currentResIndex] : null
+                    property var validRates: currentRes ? currentRes.rates : (modelData.refreshRates !== undefined ? modelData.refreshRates : [])
                     property real currentRate: modelData.refreshRate !== undefined ? modelData.refreshRate : (parseFloat(modelData.framerate) || 60)
                     readonly property int currentRateIndex: displayTabRoot.nearestRateIndex(validRates, currentRate)
+                    readonly property string currentResolution: currentRes ? (currentRes.width + "x" + currentRes.height) : (modelData.dimensions || "")
+                    readonly property string resolutionDisplay: currentResolution !== "" ? currentResolution.split("x").join(" × ") : ""
+                    readonly property string currentModeStr: {
+                        let d = validRates[currentRateIndex];
+                        return d ? d.mode : "";
+                    }
+
+                    function syncResIndexFromModel() {
+                        if (!modelData.dimensions) return;
+                        let p = modelData.dimensions.split("x");
+                        let w = parseInt(p[0]);
+                        let h = parseInt(p[1]);
+                        for (let i = 0; i < resList.length; i++) {
+                            if (resList[i].width === w && resList[i].height === h) {
+                                currentResIndex = i;
+                                return;
+                            }
+                        }
+                    }
 
                     onMonSettingsChanged: {
                         if (monSettings.powerEnabled !== undefined) {
@@ -731,11 +758,10 @@ Item {
                         if (monSettings.powerEnabled === undefined && modelData.active !== undefined) {
                             monitorPowered = modelData.active;
                         }
-                        if (displayTabRoot.pendingMonScaleName !== monName) {
+                        if (displayTabRoot.pendingModeName !== monName) {
                             currentScale = modelData.scale !== undefined ? modelData.scale : 1.0;
-                        }
-                        if (displayTabRoot.pendingMonRateName !== monName) {
                             currentRate = modelData.refreshRate !== undefined ? modelData.refreshRate : (parseFloat(modelData.framerate) || 60);
+                            syncResIndexFromModel();
                         }
                     }
 
@@ -765,7 +791,7 @@ Item {
                             Item { Layout.fillWidth: true }
 
                             Text {
-                                text: modelData.dimensions + " • " + modelData.framerate + "Hz"
+                                text: monDelegate.resolutionDisplay + " • " + Math.round(monDelegate.currentRate) + "Hz"
                                 font.family: ThemeBackend.fontFamily
                                 font.pixelSize: rootObj.s(12)
                                 color: ThemeBackend.subtext0
@@ -1120,6 +1146,96 @@ Item {
 
                         Rectangle {
                             Layout.fillWidth: true
+                            implicitHeight: rowResolutionLayout.implicitHeight + rootObj.s(24)
+                            radius: ThemeBackend.borderRadius
+                            color: Qt.alpha(ThemeBackend.surface1, 0.35)
+                            border.width: 0
+
+                            RowLayout {
+                                id: rowResolutionLayout
+                                anchors.left: parent.left
+                                anchors.leftMargin: rootObj.s(14)
+                                anchors.right: parent.right
+                                anchors.rightMargin: rootObj.s(14)
+                                anchors.verticalCenter: parent.verticalCenter
+                                spacing: rootObj.s(12)
+
+                                IconButton {
+                                    enabled: false
+                                    size: rootObj.s(32)
+                                    Layout.preferredWidth: rootObj.s(32)
+                                    Layout.preferredHeight: rootObj.s(32)
+                                    Layout.alignment: Qt.AlignVCenter
+                                    cornerRadius: ThemeBackend.borderRadius
+                                    buttonIcon: "󰍹"
+                                    iconFontSize: rootObj.s(16)
+                                    accentColor: ThemeBackend.surface0
+                                    textColor: "#ffffff"
+                                }
+
+                                ColumnLayout {
+                                    Layout.fillWidth: true
+                                    Layout.alignment: Qt.AlignVCenter
+                                    spacing: rootObj.s(2)
+
+                                    Text {
+                                        Layout.fillWidth: true
+                                        text: I18n.t("guide.display.resolution.title")
+                                        font.family: ThemeBackend.fontFamily
+                                        font.pixelSize: rootObj.s(13)
+                                        color: ThemeBackend.text
+                                    }
+
+                                    Text {
+                                        Layout.fillWidth: true
+                                        text: I18n.t("guide.display.resolution.desc")
+                                        font.family: ThemeBackend.fontFamily
+                                        font.pixelSize: rootObj.s(11)
+                                        color: ThemeBackend.subtext0
+                                    }
+                                }
+
+                                Dropdown {
+                                    id: resolutionDropdown
+                                    Layout.preferredWidth: rootObj.s(150)
+                                    Layout.preferredHeight: rootObj.s(32)
+                                    Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                    options: monDelegate.resOptions
+                                    currentIndex: monDelegate.currentResIndex
+                                    enabled: monDelegate.resOptions.length > 1
+                                    fontFamily: ThemeBackend.fontFamily
+                                    fontPixelSize: rootObj.s(11)
+                                    accentColor: ThemeBackend.mauve
+                                    baseColor: ThemeBackend.surface0
+                                    hoverColor: Qt.alpha(ThemeBackend.surface1, 0.6)
+                                    dropdownColor: ThemeBackend.surface0
+                                    borderColor: Qt.alpha(ThemeBackend.surface1, 0.5)
+                                    textColor: ThemeBackend.text
+                                    activeTextColor: ThemeBackend.crust
+                                    subTextColor: ThemeBackend.subtext0
+                                    onSelected: function(index, value) {
+                                        if (index === monDelegate.currentResIndex) return;
+                                        if (index < 0 || index >= monDelegate.resList.length) return;
+                                        monDelegate.currentResIndex = index;
+                                        let res = monDelegate.resList[index];
+                                        let rates = (res && res.rates) ? res.rates : [];
+                                        let chosen = rates.length > 0 ? rates[displayTabRoot.nearestRateIndex(rates, monDelegate.currentRate)] : null;
+                                        if (chosen) {
+                                            monDelegate.currentRate = chosen.rate;
+                                            displayTabRoot.queueModeApply(monDelegate.monName, {
+                                                mode: chosen.mode,
+                                                rate: chosen.rate,
+                                                resolution: res.width + "x" + res.height,
+                                                scale: monDelegate.currentScale
+                                            });
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        Rectangle {
+                            Layout.fillWidth: true
                             implicitHeight: rowRefreshLayout.implicitHeight + rootObj.s(24)
                             radius: ThemeBackend.borderRadius
                             color: Qt.alpha(ThemeBackend.surface1, 0.35)
@@ -1178,7 +1294,7 @@ Item {
                                         Layout.preferredWidth: rootObj.s(32)
                                         Layout.preferredHeight: rootObj.s(32)
                                         Layout.alignment: Qt.AlignVCenter
-                                        running: rateDebounceTimer.running && displayTabRoot.pendingMonRateName === monDelegate.monName
+                                        running: modeDebounceTimer.running && displayTabRoot.pendingModeName === monDelegate.monName
                                         accentColor: ThemeBackend.mauve
                                     }
 
@@ -1210,19 +1326,16 @@ Item {
                                             let data = monDelegate.validRates[i];
                                             if (data && Math.abs(monDelegate.currentRate - data.rate) > 0.01) {
                                                 monDelegate.currentRate = data.rate;
-                                                displayTabRoot.pendingMonRateName = monDelegate.monName;
-                                                displayTabRoot.pendingMonRateData = data;
-                                                rateDebounceTimer.restart();
+                                                displayTabRoot.queueModeApply(monDelegate.monName, {
+                                                    mode: data.mode,
+                                                    rate: data.rate,
+                                                    resolution: monDelegate.currentResolution,
+                                                    scale: monDelegate.currentScale
+                                                });
                                             }
                                         }
                                         onDragFinished: {
-                                            rateDebounceTimer.stop();
-                                            if (displayTabRoot.pendingMonRateName !== "" && displayTabRoot.pendingMonRateData) {
-                                                displayTabRoot.applyMonitorRefreshRate(displayTabRoot.pendingMonRateName, displayTabRoot.pendingMonRateData);
-                                                displayTabRoot.updateMonitorSetting(displayTabRoot.pendingMonRateName, "refreshRate", displayTabRoot.pendingMonRateData.rate);
-                                                displayTabRoot.pendingMonRateName = "";
-                                                displayTabRoot.pendingMonRateData = null;
-                                            }
+                                            displayTabRoot.flushModeApply(monDelegate.monName);
                                         }
                                     }
                                 }
@@ -1289,7 +1402,7 @@ Item {
                                         Layout.preferredWidth: rootObj.s(32)
                                         Layout.preferredHeight: rootObj.s(32)
                                         Layout.alignment: Qt.AlignVCenter
-                                        running: scaleDebounceTimer.running && displayTabRoot.pendingMonScaleName === monDelegate.monName
+                                        running: modeDebounceTimer.running && displayTabRoot.pendingModeName === monDelegate.monName
                                         accentColor: ThemeBackend.mauve
                                     }
 
@@ -1319,18 +1432,16 @@ Item {
                                             let s = monDelegate.validScales[i] !== undefined ? monDelegate.validScales[i] : 1.0;
                                             if (monDelegate.currentScale !== s) {
                                                 monDelegate.currentScale = s;
-                                                displayTabRoot.pendingMonScaleName = monDelegate.monName;
-                                                displayTabRoot.pendingMonScaleVal = s;
-                                                scaleDebounceTimer.restart();
+                                                displayTabRoot.queueModeApply(monDelegate.monName, {
+                                                    mode: monDelegate.currentModeStr,
+                                                    rate: monDelegate.currentRate,
+                                                    resolution: monDelegate.currentResolution,
+                                                    scale: s
+                                                });
                                             }
                                         }
                                         onDragFinished: {
-                                            scaleDebounceTimer.stop();
-                                            if (displayTabRoot.pendingMonScaleName !== "") {
-                                                displayTabRoot.applyMonitorScale(displayTabRoot.pendingMonScaleName, displayTabRoot.pendingMonScaleVal);
-                                                displayTabRoot.updateMonitorSetting(displayTabRoot.pendingMonScaleName, "scale", displayTabRoot.pendingMonScaleVal);
-                                                displayTabRoot.pendingMonScaleName = "";
-                                            }
+                                            displayTabRoot.flushModeApply(monDelegate.monName);
                                         }
                                     }
                                 }

--- a/src/quickshell/guide/display/DisplayMainTab.qml
+++ b/src/quickshell/guide/display/DisplayMainTab.qml
@@ -41,6 +41,9 @@ Item {
     property string pendingMonScaleName: ""
     property real pendingMonScaleVal: 1.0
 
+    property string pendingMonRateName: ""
+    property var pendingMonRateData: null
+
     readonly property string detectedCity: {
         if (typeof Location !== "undefined" && Location.city && Location.city !== "Unknown") {
             return Location.city;
@@ -256,6 +259,42 @@ Item {
         return best;
     }
 
+    function formatRate(rv) {
+        let n = Number(rv);
+        if (isNaN(n)) return "60";
+        let s = n.toFixed(3).replace(/0+$/, "").replace(/\.$/, "");
+        return s === "" ? "0" : s;
+    }
+
+    function normalizeRates(rates) {
+        let seen = {};
+        let out = [];
+        for (let i = 0; i < rates.length; i++) {
+            let r = rates[i];
+            if (!r || isNaN(r.rate)) continue;
+            let key = Number(r.rate).toFixed(2);
+            if (seen[key]) continue;
+            seen[key] = true;
+            out.push({ rate: Number(r.rate), mode: r.mode });
+        }
+        out.sort((a, b) => a.rate - b.rate);
+        return out;
+    }
+
+    function nearestRateIndex(validRates, target) {
+        if (!validRates || validRates.length === 0) return 0;
+        let best = 0;
+        let bestDiff = Math.abs(validRates[0].rate - target);
+        for (let i = 1; i < validRates.length; i++) {
+            let diff = Math.abs(validRates[i].rate - target);
+            if (diff < bestDiff) {
+                best = i;
+                bestDiff = diff;
+            }
+        }
+        return best;
+    }
+
     Process {
         id: monitorDetector
         running: false
@@ -285,13 +324,26 @@ Item {
                             let m = modes[modeIdx] || modes[0] || {};
                             let w = m.width || 0;
                             let h = m.height || 0;
-                            let rr = m.refresh_rate ? Math.round(m.refresh_rate / 1000) : 60;
+                            let rr = m.refresh_rate ? (m.refresh_rate / 1000) : 60;
                             let sc = item.scale !== undefined ? item.scale : 1.0;
                             let isOff = item.active === false || item.is_active === false || (modes.length > 0 && (item.current_mode === null || item.current_mode === undefined));
+                            let rates = [];
+                            for (let j = 0; j < modes.length; j++) {
+                                let mo = modes[j];
+                                if (!mo || mo.width !== w || mo.height !== h) continue;
+                                let rv = (mo.refresh_rate || 60000) / 1000;
+                                rates.push({ rate: rv, mode: w + "x" + h + "@" + displayTabRoot.formatRate(rv) });
+                            }
+                            rates = displayTabRoot.normalizeRates(rates);
+                            if (rates.length === 0 && w > 0 && h > 0) {
+                                rates.push({ rate: rr, mode: w + "x" + h + "@" + displayTabRoot.formatRate(rr) });
+                            }
                             mList.push({
                                 name: k,
                                 dimensions: w + "x" + h,
-                                framerate: rr.toString(),
+                                framerate: Math.round(rr).toString(),
+                                refreshRate: rr,
+                                refreshRates: rates,
                                 scale: sc,
                                 active: !isOff
                             });
@@ -304,13 +356,27 @@ Item {
                                 let cm = item.current_mode || {};
                                 let w = cm.width || item.rect?.width || 0;
                                 let h = cm.height || item.rect?.height || 0;
-                                let rr = cm.refresh ? Math.round(cm.refresh / 1000) : 60;
+                                let rr = cm.refresh ? (cm.refresh / 1000) : 60;
                                 let sc = item.scale !== undefined ? item.scale : 1.0;
                                 let isOff = item.active === false;
+                                let rates = [];
+                                let modes = item.modes || [];
+                                for (let j = 0; j < modes.length; j++) {
+                                    let mo = modes[j];
+                                    if (!mo || mo.width !== w || mo.height !== h) continue;
+                                    let rv = (mo.refresh || 60000) / 1000;
+                                    rates.push({ rate: rv, mode: w + "x" + h + "@" + displayTabRoot.formatRate(rv) + "Hz" });
+                                }
+                                rates = displayTabRoot.normalizeRates(rates);
+                                if (rates.length === 0 && w > 0 && h > 0) {
+                                    rates.push({ rate: rr, mode: w + "x" + h + "@" + displayTabRoot.formatRate(rr) + "Hz" });
+                                }
                                 mList.push({
                                     name: name,
                                     dimensions: w + "x" + h,
-                                    framerate: rr.toString(),
+                                    framerate: Math.round(rr).toString(),
+                                    refreshRate: rr,
+                                    refreshRates: rates,
                                     scale: sc,
                                     active: !isOff
                                 });
@@ -323,13 +389,27 @@ Item {
                                 let name = item.name || "";
                                 let w = item.width || 0;
                                 let h = item.height || 0;
-                                let rr = item.refreshRate ? Math.round(item.refreshRate) : 60;
+                                let rr = item.refreshRate ? item.refreshRate : 60;
                                 let sc = item.scale !== undefined ? item.scale : 1.0;
                                 let isOff = item.disabled === true;
+                                let rates = [];
+                                let modes = item.availableModes || [];
+                                for (let j = 0; j < modes.length; j++) {
+                                    let mm = /^(\d+)x(\d+)@([\d.]+)(?:Hz)?$/.exec(modes[j]);
+                                    if (!mm) continue;
+                                    if (parseInt(mm[1]) !== w || parseInt(mm[2]) !== h) continue;
+                                    rates.push({ rate: parseFloat(mm[3]), mode: mm[1] + "x" + mm[2] + "@" + mm[3] });
+                                }
+                                rates = displayTabRoot.normalizeRates(rates);
+                                if (rates.length === 0 && w > 0 && h > 0) {
+                                    rates.push({ rate: rr, mode: w + "x" + h + "@" + displayTabRoot.formatRate(rr) });
+                                }
                                 mList.push({
                                     name: name,
                                     dimensions: w + "x" + h,
-                                    framerate: rr.toString(),
+                                    framerate: Math.round(rr).toString(),
+                                    refreshRate: rr,
+                                    refreshRates: rates,
                                     scale: sc,
                                     active: !isOff
                                 });
@@ -420,6 +500,21 @@ Item {
         }
     }
 
+    function applyMonitorRefreshRate(monName, rateData) {
+        if (!monName || !rateData || !rateData.mode) return;
+        let modeStr = rateData.mode;
+        if (displayTabRoot.compositor === "niri") {
+            Quickshell.execDetached(["bash", "-c", "niri msg output " + monName + " mode " + modeStr]);
+        } else if (displayTabRoot.compositor === "sway") {
+            Quickshell.execDetached(["bash", "-c", "swaymsg output " + monName + " mode " + modeStr]);
+        } else {
+            let mon = displayTabRoot.monitorsList.find(m => m.name === monName);
+            let scaleVal = mon ? mon.scale : 1.0;
+            let luaCmd = 'hl.monitor({ output = "' + monName + '", mode = "' + modeStr + '", position = "auto", scale = ' + scaleVal.toString() + ' })';
+            Quickshell.execDetached(["bash", "-c", "hyprctl eval '" + luaCmd + "' || hyprctl keyword monitor " + monName + "," + modeStr + ",auto," + scaleVal.toString()]);
+        }
+    }
+
     function updateMonitorSettingDebounced(monName, tempVal) {
         pendingMonName = monName;
         pendingMonTemp = tempVal;
@@ -461,6 +556,22 @@ Item {
                 displayTabRoot.applyMonitorScale(displayTabRoot.pendingMonScaleName, displayTabRoot.pendingMonScaleVal);
                 displayTabRoot.updateMonitorSetting(displayTabRoot.pendingMonScaleName, "scale", displayTabRoot.pendingMonScaleVal);
                 displayTabRoot.pendingMonScaleName = "";
+            }
+        }
+    }
+
+    Timer {
+        id: rateDebounceTimer
+        interval: 1000
+        repeat: false
+        onTriggered: {
+            if (displayTabRoot.pendingMonRateName !== "" && displayTabRoot.pendingMonRateData) {
+                let name = displayTabRoot.pendingMonRateName;
+                let data = displayTabRoot.pendingMonRateData;
+                displayTabRoot.applyMonitorRefreshRate(name, data);
+                displayTabRoot.updateMonitorSetting(name, "refreshRate", data.rate);
+                displayTabRoot.pendingMonRateName = "";
+                displayTabRoot.pendingMonRateData = null;
             }
         }
     }
@@ -601,6 +712,10 @@ Item {
                         return ni >= 0 ? ni : 0;
                     }
 
+                    property var validRates: modelData.refreshRates !== undefined ? modelData.refreshRates : []
+                    property real currentRate: modelData.refreshRate !== undefined ? modelData.refreshRate : (parseFloat(modelData.framerate) || 60)
+                    readonly property int currentRateIndex: displayTabRoot.nearestRateIndex(validRates, currentRate)
+
                     onMonSettingsChanged: {
                         if (monSettings.powerEnabled !== undefined) {
                             monitorPowered = monSettings.powerEnabled;
@@ -618,6 +733,9 @@ Item {
                         }
                         if (displayTabRoot.pendingMonScaleName !== monName) {
                             currentScale = modelData.scale !== undefined ? modelData.scale : 1.0;
+                        }
+                        if (displayTabRoot.pendingMonRateName !== monName) {
+                            currentRate = modelData.refreshRate !== undefined ? modelData.refreshRate : (parseFloat(modelData.framerate) || 60);
                         }
                     }
 
@@ -993,6 +1111,117 @@ Item {
                                                         displayTabRoot.flushMonitorSetting(monDelegate.monName);
                                                     }
                                                 }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        Rectangle {
+                            Layout.fillWidth: true
+                            implicitHeight: rowRefreshLayout.implicitHeight + rootObj.s(24)
+                            radius: ThemeBackend.borderRadius
+                            color: Qt.alpha(ThemeBackend.surface1, 0.35)
+                            border.width: 0
+
+                            RowLayout {
+                                id: rowRefreshLayout
+                                anchors.left: parent.left
+                                anchors.leftMargin: rootObj.s(14)
+                                anchors.right: parent.right
+                                anchors.rightMargin: rootObj.s(14)
+                                anchors.verticalCenter: parent.verticalCenter
+                                spacing: rootObj.s(12)
+
+                                IconButton {
+                                    enabled: false
+                                    size: rootObj.s(32)
+                                    Layout.preferredWidth: rootObj.s(32)
+                                    Layout.preferredHeight: rootObj.s(32)
+                                    Layout.alignment: Qt.AlignVCenter
+                                    cornerRadius: ThemeBackend.borderRadius
+                                    buttonIcon: "󰑓"
+                                    iconFontSize: rootObj.s(16)
+                                    accentColor: ThemeBackend.surface0
+                                    textColor: "#ffffff"
+                                }
+
+                                ColumnLayout {
+                                    Layout.fillWidth: true
+                                    Layout.alignment: Qt.AlignVCenter
+                                    spacing: rootObj.s(2)
+
+                                    Text {
+                                        Layout.fillWidth: true
+                                        text: I18n.t("guide.display.refreshrate.title")
+                                        font.family: ThemeBackend.fontFamily
+                                        font.pixelSize: rootObj.s(13)
+                                        color: ThemeBackend.text
+                                    }
+
+                                    Text {
+                                        Layout.fillWidth: true
+                                        text: I18n.t("guide.display.refreshrate.desc")
+                                        font.family: ThemeBackend.fontFamily
+                                        font.pixelSize: rootObj.s(11)
+                                        color: ThemeBackend.subtext0
+                                    }
+                                }
+
+                                RowLayout {
+                                    Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                    spacing: rootObj.s(4)
+
+                                    LoaderIcon {
+                                        id: refreshLoader
+                                        Layout.preferredWidth: rootObj.s(32)
+                                        Layout.preferredHeight: rootObj.s(32)
+                                        Layout.alignment: Qt.AlignVCenter
+                                        running: rateDebounceTimer.running && displayTabRoot.pendingMonRateName === monDelegate.monName
+                                        accentColor: ThemeBackend.mauve
+                                    }
+
+                                    Draggable {
+                                        id: refreshRateSlider
+                                        implicitWidth: rootObj.s(220)
+                                        implicitHeight: rootObj.s(18)
+                                        enabled: monDelegate.validRates.length > 1
+                                        from: 0
+                                        to: Math.max(0, monDelegate.validRates.length - 1)
+                                        stepSize: 1
+                                        defaultValue: Math.max(0, monDelegate.validRates.length - 1)
+                                        showValueBubble: true
+                                        showTooltip: true
+                                        alwaysShowHandle: false
+                                        valueFormatter: function(idx) {
+                                            let i = Math.round(idx);
+                                            let data = monDelegate.validRates[i];
+                                            let r = data ? data.rate : monDelegate.currentRate;
+                                            return Math.round(r) + " Hz";
+                                        }
+                                        value: monDelegate.currentRateIndex
+                                        backgroundColor: ThemeBackend.surface0
+                                        accentColor: ThemeBackend.mauve
+                                        handleColor: ThemeBackend.text
+                                        handleBorderColor: ThemeBackend.mantle
+                                        onMoved: function(idx) {
+                                            let i = Math.round(idx);
+                                            let data = monDelegate.validRates[i];
+                                            if (data && Math.abs(monDelegate.currentRate - data.rate) > 0.01) {
+                                                monDelegate.currentRate = data.rate;
+                                                displayTabRoot.pendingMonRateName = monDelegate.monName;
+                                                displayTabRoot.pendingMonRateData = data;
+                                                rateDebounceTimer.restart();
+                                            }
+                                        }
+                                        onDragFinished: {
+                                            rateDebounceTimer.stop();
+                                            if (displayTabRoot.pendingMonRateName !== "" && displayTabRoot.pendingMonRateData) {
+                                                displayTabRoot.applyMonitorRefreshRate(displayTabRoot.pendingMonRateName, displayTabRoot.pendingMonRateData);
+                                                displayTabRoot.updateMonitorSetting(displayTabRoot.pendingMonRateName, "refreshRate", displayTabRoot.pendingMonRateData.rate);
+                                                displayTabRoot.pendingMonRateName = "";
+                                                displayTabRoot.pendingMonRateData = null;
                                             }
                                         }
                                     }

--- a/src/quickshell/qmldir
+++ b/src/quickshell/qmldir
@@ -37,6 +37,7 @@ singleton ThemeBackend 1.0 singletons/theme/ThemeBackend.qml
 singleton Wallpaper 1.0 singletons/theme/Wallpaper.qml
 
 singleton BlueLight 1.0 singletons/environment/BlueLight.qml
+singleton DisplayManager 1.0 singletons/environment/DisplayManager.qml
 singleton Location 1.0 singletons/environment/Location.qml
 singleton Weather 1.0 singletons/environment/Weather.qml
 

--- a/src/quickshell/reusables/Draggable.qml
+++ b/src/quickshell/reusables/Draggable.qml
@@ -294,7 +294,7 @@ Item {
     Rectangle {
         id: valueBubble
         property real previewVal: root._keyboardActive ? root.effectiveValue : root.valueAtPos(sliderMa.mouseX, sliderMa.mouseY)
-        property bool shouldShow: root.showTooltip && !root.isDragging && (root.isHoveredOrHighlighted || root._keyboardActive) && (root.valueFormatter(previewVal) !== root.valueFormatter(root.effectiveValue))
+        property bool shouldShow: root.showTooltip && !root.isDragging && (root.isHoveredOrHighlighted || root._keyboardActive) && (previewVal !== root.effectiveValue)
 
         visible: opacity > 0.001
         opacity: shouldShow ? 1.0 : 0.0

--- a/src/quickshell/singletons/environment/DisplayManager.qml
+++ b/src/quickshell/singletons/environment/DisplayManager.qml
@@ -1,0 +1,125 @@
+pragma Singleton
+import QtQuick
+import Quickshell
+import "../../"
+
+Item {
+    id: root
+    visible: false
+
+    readonly property string compositor: {
+        let de = (SystemInfo.desktopEnv || "").toLowerCase();
+        if (de.indexOf("niri") !== -1) return "niri";
+        if (de.indexOf("sway") !== -1) return "sway";
+        return "hyprland";
+    }
+
+    property bool initialApplied: false
+
+    function sh(cmd) {
+        Quickshell.execDetached(["bash", "-c", cmd]);
+    }
+
+    function formatRate(rv) {
+        let n = Number(rv);
+        if (isNaN(n)) return "60";
+        let s = n.toFixed(3).replace(/0+$/, "").replace(/\.$/, "");
+        return s === "" ? "0" : s;
+    }
+
+    function buildMode(resolution, rate) {
+        if (!resolution) return "";
+        let r = root.formatRate(rate);
+        return root.compositor === "sway" ? (resolution + "@" + r + "Hz") : (resolution + "@" + r);
+    }
+
+    function applyPower(monName, enabled, modeStr, scaleVal) {
+        if (!monName) return;
+        if (root.compositor === "niri") {
+            root.sh(enabled ? "niri msg output " + monName + " on" : "niri msg output " + monName + " off");
+        } else if (root.compositor === "sway") {
+            root.sh("swaymsg output " + monName + (enabled ? " enable" : " disable"));
+        } else {
+            if (!enabled) {
+                root.sh("hyprctl eval 'hl.monitor({ output = \"" + monName + "\", disabled = true })'");
+                return;
+            }
+            let mode = (modeStr && modeStr !== "") ? modeStr : "preferred";
+            let sc = (scaleVal !== undefined && scaleVal !== null) ? scaleVal : 1.0;
+            let luaCmd = 'hl.monitor({ output = "' + monName + '", mode = "' + mode + '", position = "auto", scale = ' + sc.toString() + ', disabled = false })';
+            root.sh("hyprctl eval '" + luaCmd + "' || hyprctl keyword monitor " + monName + "," + mode + ",auto," + sc.toString());
+        }
+    }
+
+    function applyMode(monName, modeStr, scaleVal) {
+        if (!monName) return;
+        let hasMode = modeStr !== undefined && modeStr !== null && modeStr !== "";
+        let hasScale = scaleVal !== undefined && scaleVal !== null;
+        if (root.compositor === "niri") {
+            let parts = [];
+            if (hasMode) parts.push("niri msg output " + monName + " mode " + modeStr);
+            if (hasScale) parts.push("niri msg output " + monName + " scale " + scaleVal.toString());
+            if (parts.length > 0) root.sh(parts.join(" && "));
+        } else if (root.compositor === "sway") {
+            let parts = [];
+            if (hasMode) parts.push("swaymsg output " + monName + " mode " + modeStr);
+            if (hasScale) parts.push("swaymsg output " + monName + " scale " + scaleVal.toString());
+            if (parts.length > 0) root.sh(parts.join(" && "));
+        } else {
+            let mode = hasMode ? modeStr : "preferred";
+            let sc = hasScale ? scaleVal : 1.0;
+            let luaCmd = 'hl.monitor({ output = "' + monName + '", mode = "' + mode + '", position = "auto", scale = ' + sc.toString() + ' })';
+            root.sh("hyprctl eval '" + luaCmd + "' || hyprctl keyword monitor " + monName + "," + mode + ",auto," + sc.toString());
+        }
+    }
+
+    function reapplyAll() {
+        if (typeof Config === "undefined") return;
+        let ds = Config.getSetting("display", {"monitors": {}});
+        if (!ds || !ds.monitors) return;
+        let keys = Object.keys(ds.monitors);
+        for (let i = 0; i < keys.length; i++) {
+            let name = keys[i];
+            let m = ds.monitors[name];
+            if (!m) continue;
+            let scale = m.scale !== undefined ? m.scale : 1.0;
+            if (m.powerEnabled === false) {
+                root.applyPower(name, false, "", scale);
+                continue;
+            }
+            let mode = m.mode !== undefined ? m.mode : "";
+            if (mode === "" && m.resolution !== undefined && m.refreshRate !== undefined) {
+                mode = root.buildMode(m.resolution, m.refreshRate);
+            }
+            if (mode !== "") {
+                root.applyMode(name, mode, scale);
+            }
+        }
+    }
+
+    function ensureInitialApply() {
+        if (root.initialApplied) return;
+        if (typeof Config === "undefined") return;
+        let ds = Config.getSetting("display", null);
+        if (!ds || !ds.monitors || Object.keys(ds.monitors).length === 0) return;
+        root.initialApplied = true;
+        root.reapplyAll();
+    }
+
+    Component.onCompleted: startupTimer.start()
+
+    Timer {
+        id: startupTimer
+        interval: 1500
+        repeat: false
+        onTriggered: root.ensureInitialApply()
+    }
+
+    Connections {
+        target: typeof Config !== "undefined" ? Config : null
+        ignoreUnknownSignals: true
+        function onSettingsLoaded() {
+            root.ensureInitialApply();
+        }
+    }
+}


### PR DESCRIPTION
Adds resolution and refresh rate controls to each monitor in the Display tab, and makes the selection survive a reboot. I folded this into the existing refresh PR instead of opening another one, since resolution and refresh are really the same control and the new bits build on the same code.

**Config / skeleton change (please read first)**
- New `DisplayManager` singleton (`singletons/environment/DisplayManager.qml`, registered in `qmldir`). It owns the compositor-specific monitor commands (`applyMode`, `applyPower`) and re-applies saved settings on startup, the same way `BlueLight` already does. The command logic that used to live in `DisplayMainTab` moved here so the UI and the startup path share one implementation.
- `display.monitors.<name>` gains two optional fields: `resolution` (`"WxH"`) and `mode` (the compositor-native mode string). Additive and backward compatible — nothing is read for a monitor that has no saved mode. No compositor config files are touched.

**Resolution**
- The monitor detector groups every mode the compositor reports into unique resolutions, largest first. The tab gets a resolution dropdown; picking one re-fills the refresh slider and snaps to the nearest rate. It's disabled when there's only one resolution.

**Refresh rate**
- Same slider as before, now driven by the selected resolution's rates. Also fixed the hover tooltip, which compared formatted strings and so disappeared once two rates rounded to the same label (119.88 and 120 Hz on 1080p); it now compares the raw step values.

**Persistence**
- Changing resolution/refresh/scale stores the mode (plus resolution, refresh rate and scale) in settings. On the next login `DisplayManager` replays it, so the choice survives a reboot. If a monitor has no saved mode it is left untouched, so existing users see no change.

**Testing**
- Tested on Hyprland across 2560x1440 (60/100/120/144/165/180 Hz) and 1920x1080. Switching resolution and refresh applies immediately, the refresh list follows the selected resolution, clicking a slider updates its handle right away, the tooltip shows across the whole track, and settings come back after a shell restart. Niri and Sway reuse the existing command builders but I can't test those here.

**Known limitation:** mode changes set `position = "auto"` (carried over from the existing scale slider), so monitor positions aren't preserved.
