### PR TITLE
feat: add a markdown notepad to quick actions

### DIFF
--- a/src/assets/languages/en.json
+++ b/src/assets/languages/en.json
@@ -781,6 +781,14 @@
         "pomo_skipped_focus_body": "Focus session skipped. Moving to break.",
         "pomo_skipped_break_body": "Break skipped. Moving back to focus."
       }
+    },
+    "notepad": {
+      "title": "Notes",
+      "new": "New",
+      "empty_list": "No notes yet.\nTap New to create one.",
+      "untitled": "Untitled note",
+      "tap_to_write": "Tap to write...",
+      "placeholder": "Write in markdown..."
     }
   },
   "screenshot": {

--- a/src/assets/languages/es.json
+++ b/src/assets/languages/es.json
@@ -825,6 +825,14 @@
         "pomo_skipped_focus_body": "Sesión de enfoque omitida. Pasando al descanso.",
         "pomo_skipped_break_body": "Descanso omitido. Volviendo al enfoque."
       }
+    },
+    "notepad": {
+      "title": "Notas",
+      "new": "Nueva",
+      "empty_list": "Aun no hay notas.\nPulsa Nueva para crear una.",
+      "untitled": "Nota sin titulo",
+      "tap_to_write": "Toca para escribir...",
+      "placeholder": "Escribe en markdown..."
     }
   },
   "screenshot": {

--- a/src/assets/languages/pt.json
+++ b/src/assets/languages/pt.json
@@ -781,6 +781,14 @@
         "pomo_skipped_focus_body": "Sessão de foco pulada. Indo para a pausa.",
         "pomo_skipped_break_body": "Pausa pulada. De volta ao foco."
       }
+    },
+    "notepad": {
+      "title": "Notas",
+      "new": "Nova",
+      "empty_list": "Nenhuma nota ainda.\nClique em Nova para criar.",
+      "untitled": "Nota sem titulo",
+      "tap_to_write": "Toque para escrever...",
+      "placeholder": "Escreva em markdown..."
     }
   },
   "screenshot": {

--- a/src/quickshell/qmldir
+++ b/src/quickshell/qmldir
@@ -25,6 +25,7 @@ WidgetRedactor 1.0 widgets/WidgetRedactor.qml
 Polkit 1.0 polkit/Polkit.qml
 singleton PolkitService 1.0 polkit/PolkitService.qml
 singleton NotificationManager 1.0 notifications/NotificationManager.qml
+singleton NotesManager 1.0 singletons/NotesManager.qml
 
 singleton Audio 1.0 singletons/audio/Audio.qml
 singleton Cava 1.0 singletons/audio/Cava.qml

--- a/src/quickshell/quickactions/Floating.qml
+++ b/src/quickshell/quickactions/Floating.qml
@@ -220,7 +220,7 @@ Variants {
                 id: focusTracker
                 focus: true
                 onActiveFocusChanged: {
-                    if (!activeFocus && !floatingWidget.isPinned) {
+                    if (!activeFocus && !floatingWidget.isPinned && !floatingWidget.moduleKeepAlive()) {
                         floatingWidget.isExpanded = false;
                         hideTimer.restart();
                     }
@@ -239,7 +239,8 @@ Variants {
             property var tabModules: [
                 "actions/DrawAction.qml",
                 "actions/SystemUsage.qml",
-                "actions/Timer.qml"
+                "actions/Timer.qml",
+                "actions/Notepad.qml"
             ]
 
             property int tabCount: Math.max(1, tabModules.length)
@@ -302,8 +303,18 @@ Variants {
                 return false;
             }
 
+            function moduleKeepAlive() {
+                if (typeof moduleRepeater === "undefined" || activeIndex < 0 || activeIndex >= moduleRepeater.count)
+                    return false;
+                let loader = moduleRepeater.itemAt(activeIndex);
+                if (loader && loader.status === Loader.Ready && loader.item && loader.item.keepAlive !== undefined)
+                    return loader.item.keepAlive === true;
+                return false;
+            }
+
             function kickTimer() {
                 if (!isPinned) {
+                    if (floatingWidget.moduleKeepAlive()) return;
                     if ((typeof mainHoverTracker !== "undefined" && mainHoverTracker.hovered) ||
                         (typeof sidebarDragArea !== "undefined" && (sidebarDragArea.containsMouse || sidebarDragArea.pressed)) ||
                         (typeof gridMouseArea !== "undefined" && (gridMouseArea.containsMouse || gridMouseArea.pressed)) ||
@@ -769,6 +780,10 @@ Variants {
                 interval: floatingWidget.useGraceTimer ? 3000 : 800
                 onTriggered: {
                     if (floatingWidget.isPinned) return;
+                    if (floatingWidget.moduleKeepAlive()) {
+                        hideTimer.restart();
+                        return;
+                    }
 
                     if ((typeof sidebarDragArea !== "undefined" && sidebarDragArea.pressed) ||
                         (typeof peekMouse !== "undefined" && peekMouse.pressed) ||
@@ -1226,6 +1241,7 @@ Variants {
                                 property var scaleFunc: floatingWidget.s
                                 property var mochaColors: ThemeBackend
                                 property string activeEdge: floatingWidget.activeEdge
+                                property real panelChromeLength: floatingWidget.baseSidebarH
 
                                 property bool isCurrentTarget: index === floatingWidget.activeIndex
                                 property real modWidth: (status === Loader.Ready && item && item.preferredWidth !== undefined) ? item.preferredWidth : floatingWidget.baseExpandedWidth
@@ -1269,15 +1285,6 @@ Variants {
 
                             onEntered: hideTimer.stop()
                             onExited: { if (!sidebarDragArea.containsMouse) floatingWidget.kickTimer(); }
-                            onWheel: wheel => {
-                                let step = 0;
-                                if (wheel.angleDelta.y > 0) step = (floatingWidget.activeEdge === "right" || floatingWidget.activeEdge === "top") ? 1 : -1;
-                                else if (wheel.angleDelta.y < 0) step = (floatingWidget.activeEdge === "right" || floatingWidget.activeEdge === "top") ? -1 : 1;
-
-                                if (step !== 0) {
-                                    floatingWidget.activeIndex = Math.max(0, Math.min(floatingWidget.tabCount - 1, floatingWidget.activeIndex + step));
-                                }
-                            }
                         }
                     }
 

--- a/src/quickshell/quickactions/actions/Notepad.qml
+++ b/src/quickshell/quickactions/actions/Notepad.qml
@@ -1,0 +1,420 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Quickshell
+import "../../singletons"
+import "../../"
+import "../../reusables"
+
+Item {
+    id: root
+
+    property int requestedLayoutTemplate: 1
+    property bool isActiveTab: typeof isCurrentTarget !== "undefined" ? isCurrentTarget : true
+    property bool keepAlive: inNoteView && (isEditing || titleInput.activeFocus)
+    property bool isEditing: false
+    property bool inNoteView: false
+    property bool suppressSave: false
+    property string safeActiveEdge: typeof activeEdge !== "undefined" ? activeEdge : "left"
+    property string titleDraft: ""
+
+    function s(val) {
+        return typeof scaleFunc === "function" ? scaleFunc(val) : val;
+    }
+
+    function alpha(color, a) {
+        return Qt.rgba(color.r, color.g, color.b, a);
+    }
+
+    property real baseW: s(360)
+    property real baseL: s(400)
+    property real preferredWidth: (safeActiveEdge === "bottom" || safeActiveEdge === "top") ? baseL + 50 : baseW
+
+    readonly property real panelChrome: (typeof panelChromeLength !== "undefined") ? panelChromeLength : root.s(120)
+    readonly property int noteCount: NotesManager.notesModel.count
+    readonly property int maxListRows: 6
+    readonly property real rowUnit: root.s(58)
+    readonly property real listChrome: root.s(24) + root.s(30) + root.s(8) + root.s(4)
+    readonly property real listAreaHeight: noteCount === 0 ? root.s(84) : (Math.min(noteCount, maxListRows) * root.rowUnit - root.s(4))
+    readonly property real listDesired: root.listChrome + root.listAreaHeight
+
+    readonly property real noteChrome: root.s(12) * 2 + root.s(30) + root.s(8)
+    readonly property real noteBodyContent: root.isEditing ? editorArea.paintedHeight : previewArea.paintedHeight
+    readonly property real noteDesired: root.noteChrome + Math.max(root.s(80), root.noteBodyContent + root.s(40))
+
+    property real preferredExtraLength: {
+        if (root.inNoteView) {
+            let cap = (safeActiveEdge === "bottom" || safeActiveEdge === "top") ? baseW : baseL;
+            let len = Math.max(root.s(120), root.noteDesired - root.panelChrome + root.s(8));
+            return Math.min(len, cap);
+        }
+        return Math.max(root.s(40), root.listDesired - root.panelChrome + root.s(8));
+    }
+
+    property real counterRotation: {
+        if (safeActiveEdge === "right") return 180;
+        if (safeActiveEdge === "bottom") return 90;
+        if (safeActiveEdge === "top") return -90;
+        return 0;
+    }
+
+    readonly property color cBase: ThemeBackend.base
+    readonly property color cMantle: ThemeBackend.mantle
+    readonly property color cSurface0: ThemeBackend.surface0
+    readonly property color cSurface1: ThemeBackend.surface1
+    readonly property color cText: ThemeBackend.text
+    readonly property color cSubtext0: ThemeBackend.subtext0
+    readonly property color cMauve: ThemeBackend.mauve
+
+    property var interceptedShortcuts: {
+        let keys = [];
+        if (inNoteView && titleInput.activeFocus)
+            keys = keys.concat(["Return", "Enter", "Tab", "Shift+Tab"]);
+        if (inNoteView && isEditing && editorArea.activeFocus)
+            keys = keys.concat(["Return", "Enter", "Left", "Right", "Up", "Down", "Tab", "Shift+Tab", "Backspace"]);
+        return keys;
+    }
+
+    function syncActiveNoteTitle() {
+        root.titleDraft = NotesManager.explicitTitle(NotesManager.activeNote());
+    }
+
+    function scheduleRender() {
+        if (!inNoteView || isEditing) return;
+        NotesManager.scheduleRender(NotesManager.activeId);
+    }
+
+    function beginEditing() {
+        root.isEditing = true;
+        root.suppressSave = true;
+        let note = NotesManager.activeNote();
+        editorArea.text = note ? (note.content || "") : "";
+        root.suppressSave = false;
+        Qt.callLater(() => editorArea.forceActiveFocus());
+    }
+
+    function finishEditing() {
+        if (!root.isEditing) return;
+        NotesManager.updateNoteContent(NotesManager.activeId, editorArea.text);
+        root.syncActiveNoteTitle();
+        root.isEditing = false;
+        if (NotesManager.pruneEmptyNote(NotesManager.activeId)) {
+            root.inNoteView = false;
+            return;
+        }
+        root.scheduleRender();
+    }
+
+    function openNote(id) {
+        NotesManager.setActiveId(id);
+        root.inNoteView = true;
+        root.isEditing = false;
+        root.syncActiveNoteTitle();
+        root.scheduleRender();
+    }
+
+    function closeNoteView() {
+        root.finishEditing();
+        NotesManager.pruneEmptyNote(NotesManager.activeId);
+        NotesManager.persistNotes();
+        root.inNoteView = false;
+        root.isEditing = false;
+    }
+
+    function createNote() {
+        let id = NotesManager.createNote();
+        root.openNote(id);
+        root.beginEditing();
+    }
+
+    function selectNote(id) {
+        root.finishEditing();
+        root.openNote(id);
+    }
+
+    function deleteCurrentNote() {
+        root.isEditing = false;
+        NotesManager.deleteNoteById(NotesManager.activeId);
+        root.closeNoteView();
+    }
+
+    onIsActiveTabChanged: {
+        if (!isActiveTab) {
+            root.finishEditing();
+            if (NotesManager.pruneEmptyNote(NotesManager.activeId)) {
+                root.isEditing = false;
+                root.inNoteView = false;
+            }
+        }
+    }
+
+    Component.onCompleted: {
+        if (!NotesManager.loaded)
+            NotesManager.loadFromDisk();
+        root.inNoteView = false;
+        root.syncActiveNoteTitle();
+    }
+
+    Component.onDestruction: {
+        NotesManager.pruneEmptyNote(NotesManager.activeId);
+        NotesManager.persistNotes();
+    }
+
+    Connections {
+        target: NotesManager
+        function onActiveIdChanged() {
+            root.syncActiveNoteTitle();
+        }
+    }
+
+    Item {
+        id: orientedRoot
+        anchors.centerIn: parent
+        width: (root.counterRotation % 180 !== 0) ? parent.height : parent.width
+        height: (root.counterRotation % 180 !== 0) ? parent.width : parent.height
+        rotation: root.counterRotation
+        clip: true
+
+        Rectangle {
+            anchors.fill: parent
+            color: root.cMantle
+            radius: ThemeBackend.borderRadius
+            z: -1
+        }
+
+        NotesList {
+            anchors.fill: parent
+            anchors.margins: root.s(12)
+            z: 0
+            visible: !root.inNoteView
+            opacity: root.inNoteView ? 0 : 1
+            Behavior on opacity { NumberAnimation { duration: 180 } }
+            scaleFunc: root.s
+            selectedId: NotesManager.activeId
+            onNoteActivated: (id) => root.selectNote(id)
+            onCreateRequested: root.createNote()
+        }
+
+        ColumnLayout {
+            id: noteViewLayer
+            anchors.fill: parent
+            anchors.margins: root.s(12)
+            spacing: root.s(8)
+            z: 1
+            visible: root.inNoteView
+            opacity: root.inNoteView ? 1 : 0
+            Behavior on opacity { NumberAnimation { duration: 180 } }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: root.s(6)
+                z: 2
+
+                IconButton {
+                    Layout.preferredWidth: root.s(30)
+                    Layout.preferredHeight: root.s(30)
+                    Layout.alignment: Qt.AlignVCenter
+                    cornerRadius: Math.max(0, ThemeBackend.borderRadius - root.s(2))
+                    buttonIcon: "󰁍"
+                    iconFontSize: root.s(14)
+                    accentColor: ThemeBackend.surface1
+                    textColor: isHoveredOrHighlighted ? ThemeBackend.text : ThemeBackend.subtext0
+                    onClicked: root.closeNoteView()
+                }
+
+                Item {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: root.s(24)
+
+                    TextInput {
+                        id: titleInput
+                        anchors.fill: parent
+                        text: root.titleDraft
+                        color: root.cText
+                        font.family: ThemeBackend.fontFamily
+                        font.bold: true
+                        font.pixelSize: root.s(12)
+                        horizontalAlignment: TextInput.AlignHCenter
+                        verticalAlignment: TextInput.AlignVCenter
+                        selectByMouse: true
+                        selectionColor: root.alpha(root.cMauve, 0.35)
+                        selectedTextColor: root.cText
+                        clip: true
+                        activeFocusOnTab: false
+                        onTextEdited: {
+                            root.titleDraft = text;
+                            NotesManager.updateNoteTitle(NotesManager.activeId, text);
+                        }
+                        onAccepted: titleInput.focus = false
+                        Keys.onEscapePressed: {
+                            root.syncActiveNoteTitle();
+                            titleInput.focus = false;
+                            event.accepted = true;
+                        }
+
+                        Text {
+                            anchors.fill: parent
+                            visible: titleInput.text.length === 0 && !titleInput.activeFocus
+                            text: NotesManager.derivedTitle(NotesManager.activeNote())
+                            font.family: ThemeBackend.fontFamily
+                            font.bold: true
+                            font.pixelSize: root.s(12)
+                            color: root.alpha(root.cSubtext0, 0.6)
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                            elide: Text.ElideRight
+                        }
+                    }
+                }
+
+                DeleteButton {
+                    Layout.preferredWidth: root.s(30)
+                    Layout.preferredHeight: root.s(30)
+                    Layout.alignment: Qt.AlignVCenter
+                    cornerRadius: Math.max(0, ThemeBackend.borderRadius - root.s(2))
+                    iconFontSize: root.s(14)
+                    textColor: isHoveredOrHighlighted ? ThemeBackend.crust : ThemeBackend.crust
+                    onTriggered: root.deleteCurrentNote()
+                }
+            }
+
+            Item {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                clip: true
+
+                Rectangle {
+                    anchors.fill: parent
+                    radius: ThemeBackend.borderRadius
+                    color: root.isEditing ? root.cSurface0 : root.cBase
+                    clip: true
+                    Behavior on color { ColorAnimation { duration: 180 } }
+
+                    Item {
+                        anchors.fill: parent
+                        visible: !root.isEditing
+                        opacity: root.isEditing ? 0 : 1
+                        Behavior on opacity { NumberAnimation { duration: 150 } }
+
+                        Flickable {
+                            anchors.fill: parent
+                            anchors.margins: root.s(8)
+                            contentWidth: width
+                            contentHeight: Math.max(height, previewArea.paintedHeight + root.s(48))
+                            clip: true
+                            boundsBehavior: Flickable.StopAtBounds
+
+                            TextEdit {
+                                id: previewArea
+                                width: parent.width
+                                readOnly: true
+                                selectByMouse: false
+                                focus: false
+                                textFormat: NotesManager.useQtFallback ? TextEdit.MarkdownText : TextEdit.RichText
+                                text: NotesManager.useQtFallback
+                                    ? ((NotesManager.activeNote() && NotesManager.activeNote().content)
+                                        ? NotesManager.activeNote().content : "")
+                                    : NotesManager.previewHtml
+                                color: root.cText
+                                font.family: ThemeBackend.fontFamily
+                                font.pixelSize: root.s(13)
+                                wrapMode: TextEdit.Wrap
+                            }
+                        }
+
+                        MouseArea {
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            enabled: !root.isEditing
+                            cursorShape: Qt.IBeamCursor
+
+                            property real pressY: 0
+                            property bool didDrag: false
+
+                            onPressed: (mouse) => {
+                                pressY = mouse.y;
+                                didDrag = false;
+                            }
+
+                            onPositionChanged: (mouse) => {
+                                if (!pressed || root.isEditing) return;
+                                if (Math.abs(mouse.y - pressY) > root.s(4))
+                                    didDrag = true;
+                            }
+
+                            onReleased: {
+                                if (!didDrag)
+                                    root.beginEditing();
+                            }
+
+                            onCanceled: {
+                                didDrag = false;
+                            }
+                        }
+                    }
+
+                    Item {
+                        anchors.fill: parent
+                        visible: root.isEditing
+                        opacity: root.isEditing ? 1 : 0
+                        Behavior on opacity { NumberAnimation { duration: 150 } }
+
+                        Text {
+                            anchors.top: parent.top
+                            anchors.left: parent.left
+                            anchors.margins: root.s(14)
+                            visible: editorArea.text.length === 0
+                            text: I18n.t("quickactions.notepad.placeholder")
+                            font.family: ThemeBackend.fontFamily
+                            font.pixelSize: root.s(13)
+                            color: root.alpha(root.cSubtext0, 0.65)
+                            z: 1
+                        }
+
+                        Flickable {
+                            anchors.fill: parent
+                            anchors.margins: root.s(10)
+                            contentWidth: width
+                            contentHeight: Math.max(height, editorArea.paintedHeight + root.s(24))
+                            clip: true
+                            boundsBehavior: Flickable.StopAtBounds
+
+                            TextEdit {
+                                id: editorArea
+                                width: parent.width
+                                color: root.cText
+                                font.family: ThemeBackend.fontFamily
+                                font.pixelSize: root.s(13)
+                                wrapMode: TextEdit.Wrap
+                                selectByMouse: true
+                                selectionColor: root.alpha(root.cMauve, 0.35)
+                                selectedTextColor: root.cText
+
+                                onTextChanged: {
+                                    if (root.suppressSave) return;
+                                    NotesManager.updateNoteContent(NotesManager.activeId, text);
+                                    root.syncActiveNoteTitle();
+                                }
+
+                                onActiveFocusChanged: {
+                                    if (activeFocus || !root.isEditing) return;
+                                    Qt.callLater(function() {
+                                        if (root.isEditing && !editorArea.activeFocus && !titleInput.activeFocus)
+                                            root.finishEditing();
+                                    });
+                                }
+
+                                Keys.onPressed: function(event) {
+                                    if (event.key === Qt.Key_Escape) {
+                                        root.finishEditing();
+                                        event.accepted = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/quickshell/quickactions/actions/NotesList.qml
+++ b/src/quickshell/quickactions/actions/NotesList.qml
@@ -1,0 +1,343 @@
+import QtQuick
+import QtQuick.Layouts
+import "../../singletons"
+import "../../"
+import "../../reusables"
+
+Item {
+    id: root
+
+    property var scaleFunc: null
+    property string selectedId: NotesManager.activeId
+
+    signal noteActivated(string id)
+    signal createRequested()
+
+    function s(val) {
+        return typeof scaleFunc === "function" ? scaleFunc(val) : val;
+    }
+
+    function alpha(color, a) {
+        return Qt.rgba(color.r, color.g, color.b, a);
+    }
+
+    function fmtDate(ts) {
+        if (!ts) return "";
+        let d = new Date(ts);
+        function pad(n) { return (n < 10 ? "0" : "") + n; }
+        return pad(d.getDate()) + "/" + pad(d.getMonth() + 1) + " " + pad(d.getHours()) + ":" + pad(d.getMinutes());
+    }
+
+    readonly property color cSurface1: ThemeBackend.surface1
+    readonly property color cText: ThemeBackend.text
+    readonly property color cSubtext0: ThemeBackend.subtext0
+    readonly property color cMauve: ThemeBackend.mauve
+    readonly property color cCrust: ThemeBackend.crust
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: root.s(8)
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: root.s(8)
+
+            Text {
+                Layout.alignment: Qt.AlignVCenter
+                text: I18n.t("quickactions.notepad.title")
+                font.family: ThemeBackend.fontFamily
+                font.bold: true
+                font.pixelSize: root.s(13)
+                color: root.cText
+            }
+
+            Item { Layout.fillWidth: true }
+
+            ClickButton {
+                Layout.alignment: Qt.AlignVCenter
+                buttonText: I18n.t("quickactions.notepad.new")
+                buttonIcon: "󰐕"
+                iconFontSize: root.s(12)
+                textFontSize: root.s(11)
+                horizontalPadding: root.s(10)
+                cornerRadius: Math.max(0, ThemeBackend.borderRadius - root.s(2))
+                accentColor: ThemeBackend.surface1
+                textColor: ThemeBackend.text
+                onTriggered: root.createRequested()
+            }
+        }
+
+        Item {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            clip: true
+
+            ListView {
+                id: notesList
+                anchors.fill: parent
+                spacing: root.s(4)
+                model: NotesManager.notesModel
+                clip: true
+                boundsBehavior: Flickable.StopAtBounds
+
+                Text {
+                    anchors.centerIn: parent
+                    width: parent.width - root.s(24)
+                    visible: NotesManager.notesModel.count === 0
+                    text: I18n.t("quickactions.notepad.empty_list")
+                    font.family: ThemeBackend.fontFamily
+                    font.pixelSize: root.s(11)
+                    color: root.cSubtext0
+                    horizontalAlignment: Text.AlignHCenter
+                    wrapMode: Text.Wrap
+                }
+
+                delegate: Item {
+                    id: noteWrapper
+                    width: notesList.width
+                    height: card.height
+
+                    readonly property bool isSelected: model.id === root.selectedId
+                    property bool expanded: false
+                    property real expandProgress: expanded ? 1.0 : 0.0
+                    property real dragX: 0
+                    property bool isDismissing: false
+                    property bool canExpand: {
+                        let c = model.content || "";
+                        if (c.indexOf("\n") !== -1) return true;
+                        return c.length > 60;
+                    }
+
+                    Behavior on expandProgress {
+                        enabled: !cardMa.draggingV
+                        NumberAnimation { duration: 260; easing.type: Easing.OutQuart }
+                    }
+
+                    NumberAnimation {
+                        id: resetAnim
+                        target: noteWrapper
+                        property: "dragX"
+                        to: 0
+                        duration: 200
+                        easing.type: Easing.OutCubic
+                    }
+
+                    NumberAnimation {
+                        id: dismissAnim
+                        target: noteWrapper
+                        property: "dragX"
+                        duration: 200
+                        easing.type: Easing.OutQuad
+                        property string dismissId: ""
+                        onFinished: NotesManager.deleteNoteById(dismissId)
+                    }
+
+                    Rectangle {
+                        id: card
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.top: parent.top
+
+                        readonly property real baseH: root.s(54)
+                        readonly property real expandedH: root.s(176)
+                        height: baseH + (expandedH - baseH) * noteWrapper.expandProgress
+
+                        radius: Math.min(ThemeBackend.borderRadius, root.s(12))
+                        clip: true
+                        transform: Translate { x: noteWrapper.dragX }
+                        opacity: Math.max(0.0, 1.0 - (Math.abs(noteWrapper.dragX) / (card.width * 0.75)))
+                        color: {
+                            if (noteWrapper.isSelected) return root.cMauve;
+                            if (cardMa.containsMouse && !cardMa.draggingH) return Qt.lighter(root.cSurface1, 1.04);
+                            return root.cSurface1;
+                        }
+                        Behavior on color {
+                            enabled: !cardMa.draggingH
+                            ColorAnimation { duration: 180; easing.type: Easing.OutCubic }
+                        }
+
+                        ColumnLayout {
+                            id: headerCol
+                            anchors.left: parent.left
+                            anchors.right: parent.right
+                            anchors.top: parent.top
+                            anchors.leftMargin: root.s(12)
+                            anchors.rightMargin: root.s(12)
+                            anchors.topMargin: root.s(9)
+                            spacing: root.s(1)
+
+                            RowLayout {
+                                Layout.fillWidth: true
+                                spacing: root.s(6)
+
+                                Text {
+                                    Layout.fillWidth: true
+                                    text: NotesManager.noteTitle({ content: model.content, title: model.title })
+                                    font.family: ThemeBackend.fontFamily
+                                    font.bold: true
+                                    font.pixelSize: root.s(12)
+                                    color: noteWrapper.isSelected ? root.cCrust : root.cText
+                                    elide: Text.ElideRight
+                                    Behavior on color { ColorAnimation { duration: 180 } }
+                                }
+
+                                Text {
+                                    Layout.alignment: Qt.AlignVCenter
+                                    text: root.fmtDate(model.updatedAt)
+                                    font.family: ThemeBackend.fontFamily
+                                    font.pixelSize: root.s(8)
+                                    color: noteWrapper.isSelected ? root.alpha(root.cCrust, 0.65) : root.alpha(root.cSubtext0, 0.75)
+                                    Behavior on color { ColorAnimation { duration: 180 } }
+                                }
+
+                                Text {
+                                    Layout.alignment: Qt.AlignVCenter
+                                    visible: noteWrapper.canExpand
+                                    text: noteWrapper.expanded ? "󰅁" : "󰅀"
+                                    font.family: "Iosevka Nerd Font"
+                                    font.pixelSize: root.s(11)
+                                    color: noteWrapper.isSelected ? root.alpha(root.cCrust, 0.8) : root.cSubtext0
+                                    Behavior on color { ColorAnimation { duration: 180 } }
+                                }
+                            }
+
+                            Text {
+                                Layout.fillWidth: true
+                                text: NotesManager.notePreview({ title: model.title, content: model.content })
+                                font.family: ThemeBackend.fontFamily
+                                font.pixelSize: root.s(11)
+                                color: noteWrapper.isSelected ? root.alpha(root.cCrust, 0.85) : root.cSubtext0
+                                elide: Text.ElideRight
+                                maximumLineCount: 1
+                                Behavior on color { ColorAnimation { duration: 180 } }
+                            }
+                        }
+
+                        Flickable {
+                            id: expandView
+                            anchors.left: parent.left
+                            anchors.right: parent.right
+                            anchors.top: headerCol.bottom
+                            anchors.bottom: parent.bottom
+                            anchors.leftMargin: root.s(12)
+                            anchors.rightMargin: root.s(12)
+                            anchors.topMargin: root.s(6)
+                            anchors.bottomMargin: root.s(8)
+                            visible: noteWrapper.expandProgress > 0.01
+                            opacity: Math.max(0.0, Math.min(1.0, (noteWrapper.expandProgress - 0.15) * 1.6))
+                            clip: true
+                            contentWidth: width
+                            contentHeight: expandedText.paintedHeight
+                            boundsBehavior: Flickable.StopAtBounds
+
+                            Text {
+                                id: expandedText
+                                width: parent.width
+                                text: {
+                                    let body = NotesManager.bodyMarkdown({ title: model.title, content: model.content });
+                                    return body !== "" ? body : I18n.t("quickactions.notepad.tap_to_write");
+                                }
+                                color: noteWrapper.isSelected ? root.alpha(root.cCrust, 0.9) : root.cText
+                                font.family: ThemeBackend.fontFamily
+                                font.pixelSize: root.s(11)
+                                wrapMode: Text.Wrap
+                                textFormat: Text.PlainText
+                            }
+                        }
+
+                        MouseArea {
+                            id: cardMa
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            enabled: !noteWrapper.isDismissing
+                            cursorShape: Qt.PointingHandCursor
+
+                            property real startRootX: 0
+                            property real startRootY: 0
+                            property bool draggingH: false
+                            property bool draggingV: false
+
+                            onPressed: (mouse) => {
+                                let pt = mapToItem(notesList, mouse.x, mouse.y);
+                                startRootX = pt.x;
+                                startRootY = pt.y;
+                                draggingH = false;
+                                draggingV = false;
+                                resetAnim.stop();
+                            }
+
+                            onPositionChanged: (mouse) => {
+                                if (!pressed) return;
+                                let pt = mapToItem(notesList, mouse.x, mouse.y);
+                                let dx = pt.x - startRootX;
+                                let dy = pt.y - startRootY;
+
+                                if (!draggingH && !draggingV) {
+                                    if (Math.abs(dx) > root.s(6) && Math.abs(dx) > Math.abs(dy)) {
+                                        draggingH = true;
+                                        cardMa.preventStealing = true;
+                                    } else if (noteWrapper.canExpand && Math.abs(dy) > root.s(6) && Math.abs(dy) >= Math.abs(dx)) {
+                                        draggingV = true;
+                                        cardMa.preventStealing = true;
+                                    }
+                                }
+
+                                if (draggingH) {
+                                    noteWrapper.dragX = dx;
+                                } else if (draggingV && noteWrapper.canExpand) {
+                                    let dragDist = root.s(120);
+                                    let target = noteWrapper.expanded
+                                        ? Math.max(0.0, Math.min(1.0, 1.0 + (dy / dragDist)))
+                                        : Math.max(0.0, Math.min(1.0, dy / dragDist));
+                                    noteWrapper.expandProgress = target;
+                                }
+                            }
+
+                            onReleased: (mouse) => {
+                                cardMa.preventStealing = false;
+                                if (draggingH) {
+                                    let threshold = card.width * 0.25;
+                                    if (Math.abs(noteWrapper.dragX) > threshold) {
+                                        noteWrapper.isDismissing = true;
+                                        dismissAnim.dismissId = model.id;
+                                        dismissAnim.from = noteWrapper.dragX;
+                                        dismissAnim.to = noteWrapper.dragX > 0 ? card.width * 1.2 : -card.width * 1.2;
+                                        dismissAnim.start();
+                                    } else {
+                                        resetAnim.from = noteWrapper.dragX;
+                                        resetAnim.start();
+                                    }
+                                    draggingH = false;
+                                } else if (draggingV && noteWrapper.canExpand) {
+                                    if (!noteWrapper.expanded && noteWrapper.expandProgress > 0.35) {
+                                        noteWrapper.expanded = true;
+                                        notesList.positionViewAtIndex(index, ListView.Contain);
+                                    } else if (noteWrapper.expanded && noteWrapper.expandProgress < 0.65) {
+                                        noteWrapper.expanded = false;
+                                    }
+                                    noteWrapper.expandProgress = Qt.binding(() => noteWrapper.expanded ? 1.0 : 0.0);
+                                    draggingV = false;
+                                } else {
+                                    root.noteActivated(model.id);
+                                }
+                            }
+
+                            onCanceled: {
+                                cardMa.preventStealing = false;
+                                if (draggingH) {
+                                    resetAnim.from = noteWrapper.dragX;
+                                    resetAnim.start();
+                                    draggingH = false;
+                                }
+                                if (draggingV && noteWrapper.canExpand) {
+                                    noteWrapper.expandProgress = Qt.binding(() => noteWrapper.expanded ? 1.0 : 0.0);
+                                    draggingV = false;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/quickshell/quickactions/actions/qmldir
+++ b/src/quickshell/quickactions/actions/qmldir
@@ -2,3 +2,5 @@ Dock 1.0 Dock.qml
 DrawAction 1.0 DrawAction.qml
 SystemUsage 1.0 SystemUsage.qml
 Timer 1.0 Timer.qml
+Notepad 1.0 Notepad.qml
+NotesList 1.0 NotesList.qml

--- a/src/quickshell/singletons/NotesManager.qml
+++ b/src/quickshell/singletons/NotesManager.qml
@@ -1,0 +1,372 @@
+pragma Singleton
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import "../"
+
+Item {
+    id: root
+
+    ListModel { id: notesModelInternal }
+    property alias notesModel: notesModelInternal
+
+    property string activeId: ""
+    property bool loaded: false
+    property bool suppressSave: false
+
+    property string previewHtml: ""
+    property bool useQtFallback: false
+    property string pendingRenderId: ""
+
+    readonly property string notesPath: Caching.getStateDir("notepad") + "/notes.json"
+    readonly property string renderInputPath: Caching.getRunDir("notepad") + "/render_in.json"
+    readonly property string mdRenderScript: Caching.serpantinumDir + "/scripts/notepad/md_render.py"
+
+    signal renderFinished(string noteId, string html, bool useFallback)
+
+    FileView {
+        id: notesFile
+        path: root.notesPath
+        watchChanges: false
+    }
+
+    FileView {
+        id: renderInputFile
+        path: root.renderInputPath
+    }
+
+    Process {
+        id: loadNotesProc
+        command: ["cat", root.notesPath]
+        stdout: StdioCollector {
+            id: loadNotesCollector
+            onStreamFinished: root.loadFromText(loadNotesCollector.text)
+        }
+        onExited: (exitCode) => {
+            if (!root.loaded) root.markMissing();
+        }
+    }
+
+    Timer {
+        id: saveTimer
+        interval: 400
+        repeat: false
+        onTriggered: root.persistNotes()
+    }
+
+    Timer {
+        id: renderTimer
+        interval: 120
+        repeat: false
+        property string noteId: ""
+        onTriggered: root.runPendingRender()
+    }
+
+    Process {
+        id: renderProc
+        command: ["python3", root.mdRenderScript, root.renderInputPath]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                let noteId = root.pendingRenderId;
+                if (!noteId) return;
+                let html = this.text.trim();
+                if (html !== "") {
+                    root.previewHtml = html;
+                    root.useQtFallback = false;
+                    root.renderFinished(noteId, html, false);
+                } else {
+                    root.applyQtFallback(noteId);
+                }
+                root.pendingRenderId = "";
+            }
+        }
+        onExited: (exitCode) => {
+            if (exitCode !== 0 && root.pendingRenderId)
+                root.applyQtFallback(root.pendingRenderId);
+        }
+    }
+
+    Component.onCompleted: {
+        loadFromDisk();
+        if (!renderInputFile.text() || renderInputFile.text().trim() === "")
+            renderInputFile.setText("{}");
+    }
+
+    function newId() {
+        return "n_" + Date.now().toString(36) + "_" + Math.floor(Math.random() * 1e6).toString(36);
+    }
+
+    function stripMarkdown(line) {
+        if (!line) return "";
+        line = line.replace(/^#+\s*/, "");
+        line = line.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
+        line = line.replace(/\*\*(.*?)\*\*/g, "$1");
+        line = line.replace(/__(.*?)__/g, "$1");
+        line = line.replace(/\*(.*?)\*/g, "$1");
+        line = line.replace(/`(.*?)`/g, "$1");
+        line = line.replace(/~~(.*?)~~/g, "$1");
+        line = line.replace(/\[([ xX])\]\s*/g, "");
+        line = line.replace(/(^|\s)[-*+]\s+/g, "$1");
+        line = line.replace(/(^|\s)\d+\.\s+/g, "$1");
+        return line.trim();
+    }
+
+    function derivedTitle(note) {
+        if (!note || !note.content) return I18n.t("quickactions.notepad.untitled");
+        let lines = note.content.split("\n");
+        for (let i = 0; i < lines.length; i++) {
+            let line = root.stripMarkdown(lines[i]);
+            if (line !== "") return line;
+        }
+        return I18n.t("quickactions.notepad.untitled");
+    }
+
+    function explicitTitle(note) {
+        return (note && note.title) ? note.title : "";
+    }
+
+    function noteTitle(note) {
+        if (note && note.title && note.title.trim() !== "") return note.title;
+        return root.derivedTitle(note);
+    }
+
+    function titleLineIndex(note) {
+        if (!note || !note.content) return -1;
+        let lines = note.content.split("\n");
+        for (let i = 0; i < lines.length; i++) {
+            if (root.stripMarkdown(lines[i]) !== "") return i;
+        }
+        return -1;
+    }
+
+    function bodyMarkdown(note) {
+        if (!note || !note.content) return "";
+        let lines = note.content.split("\n");
+        let idx = root.titleLineIndex(note);
+        let start = 0;
+        if (idx >= 0) {
+            let hasExplicit = note.title && note.title.trim() !== "";
+            let stripped = root.stripMarkdown(lines[idx]);
+            if (!hasExplicit || stripped === note.title.trim()) start = idx + 1;
+        }
+        return lines.slice(start).join("\n").trim();
+    }
+
+    function notePreview(note) {
+        let body = root.bodyMarkdown(note);
+        if (!body || body.trim() === "") return I18n.t("quickactions.notepad.tap_to_write");
+        let preview = root.stripMarkdown(body.replace(/\n/g, " ").replace(/\s+/g, " ").trim());
+        return preview.length > 60 ? preview.substring(0, 60) + "…" : preview;
+    }
+
+    function getNoteById(id) {
+        let idx = root.indexOfId(id);
+        return idx >= 0 ? notesModelInternal.get(idx) : null;
+    }
+
+    function indexOfId(id) {
+        for (let i = 0; i < notesModelInternal.count; i++) {
+            if (notesModelInternal.get(i).id === id) return i;
+        }
+        return -1;
+    }
+
+    function activeNote() {
+        return root.getNoteById(root.activeId);
+    }
+
+    function activeIndex() {
+        return root.indexOfId(root.activeId);
+    }
+
+    function loadFromDisk() {
+        if (!loadNotesProc.running) loadNotesProc.running = true;
+    }
+
+    function loadFromText(raw) {
+        if (root.loaded) return;
+        notesModelInternal.clear();
+        if (!raw || raw.trim() === "") {
+            root.activeId = "";
+            root.loaded = true;
+            return;
+        }
+        try {
+            let data = JSON.parse(raw);
+            let notes = Array.isArray(data.notes) ? data.notes : [];
+            for (let i = 0; i < notes.length; i++)
+                notesModelInternal.append(notes[i]);
+            root.activeId = data.activeId || "";
+            if (root.activeId && root.indexOfId(root.activeId) < 0)
+                root.activeId = notesModelInternal.count > 0 ? notesModelInternal.get(0).id : "";
+        } catch (e) {
+            notesModelInternal.clear();
+            root.activeId = "";
+        }
+        root.loaded = true;
+    }
+
+    function markMissing() {
+        notesModelInternal.clear();
+        root.activeId = "";
+        root.loaded = true;
+    }
+
+    function isEmptyNote(note) {
+        if (!note) return true;
+        let title = (note.title || "").trim();
+        let content = (note.content || "").trim();
+        return title === "" && content === "";
+    }
+
+    function pruneEmptyNote(id) {
+        let idx = root.indexOfId(id);
+        if (idx < 0) return false;
+        if (!root.isEmptyNote(notesModelInternal.get(idx))) return false;
+        notesModelInternal.remove(idx);
+        if (root.activeId === id) {
+            if (notesModelInternal.count === 0)
+                root.activeId = "";
+            else
+                root.activeId = notesModelInternal.get(Math.min(idx, notesModelInternal.count - 1)).id;
+        }
+        saveTimer.stop();
+        root.persistNotes();
+        return true;
+    }
+
+    function persistNotes() {
+        if (!root.loaded || root.suppressSave) return;
+        let notes = [];
+        let activeExists = false;
+        for (let i = 0; i < notesModelInternal.count; i++) {
+            let note = notesModelInternal.get(i);
+            if (root.isEmptyNote(note)) continue;
+            notes.push(note);
+            if (note.id === root.activeId) activeExists = true;
+        }
+        notesFile.setText(JSON.stringify({
+            activeId: activeExists ? root.activeId : "",
+            notes: notes
+        }, null, 2));
+    }
+
+    function scheduleSave() {
+        saveTimer.restart();
+    }
+
+    function setActiveId(id) {
+        root.activeId = id;
+        root.scheduleSave();
+    }
+
+    function colorToHex(c) {
+        if (!c) return "#ffffff";
+        function channel(v) {
+            let n = Math.round(Math.max(0, Math.min(1, v)) * 255);
+            let h = n.toString(16);
+            return h.length === 1 ? "0" + h : h;
+        }
+        return "#" + channel(c.r) + channel(c.g) + channel(c.b);
+    }
+
+    function themePayload() {
+        return {
+            text: colorToHex(ThemeBackend.text),
+            base: colorToHex(ThemeBackend.base),
+            mantle: colorToHex(ThemeBackend.mantle),
+            mauve: colorToHex(ThemeBackend.mauve),
+            surface0: colorToHex(ThemeBackend.surface0),
+            subtext0: colorToHex(ThemeBackend.subtext0),
+            fontFamily: ThemeBackend.fontFamily
+        };
+    }
+
+    function scheduleRender(noteId) {
+        if (!noteId) return;
+        renderTimer.noteId = noteId;
+        renderTimer.restart();
+    }
+
+    function runPendingRender() {
+        let noteId = renderTimer.noteId;
+        if (!noteId) return;
+        let note = root.getNoteById(noteId);
+        if (!note) return;
+        root.pendingRenderId = noteId;
+        renderInputFile.setText(JSON.stringify({
+            markdown: note.content || "",
+            theme: root.themePayload(),
+            emptyHint: I18n.t("quickactions.notepad.tap_to_write")
+        }));
+        renderProc.running = false;
+        renderProc.running = true;
+    }
+
+    function applyQtFallback(noteId) {
+        let note = root.getNoteById(noteId);
+        let content = note && note.content ? note.content : "";
+        root.previewHtml = content;
+        root.useQtFallback = true;
+        root.renderFinished(noteId, content, true);
+        root.pendingRenderId = "";
+    }
+
+    function updateNoteContent(id, text) {
+        let idx = root.indexOfId(id);
+        if (idx < 0) return;
+        let note = notesModelInternal.get(idx);
+        note.content = text;
+        note.updatedAt = Date.now();
+        notesModelInternal.set(idx, note);
+        root.scheduleSave();
+    }
+
+    function updateNoteTitle(id, text) {
+        let idx = root.indexOfId(id);
+        if (idx < 0) return;
+        let note = notesModelInternal.get(idx);
+        note.title = text;
+        note.updatedAt = Date.now();
+        notesModelInternal.set(idx, note);
+        root.scheduleSave();
+    }
+
+    function createNote() {
+        let note = {
+            id: root.newId(),
+            title: "",
+            content: "",
+            updatedAt: Date.now()
+        };
+        notesModelInternal.insert(0, note);
+        root.activeId = note.id;
+        root.scheduleSave();
+        return note.id;
+    }
+
+    function deleteNoteAtIndex(idx) {
+        if (idx < 0 || idx >= notesModelInternal.count) return;
+        let removedId = notesModelInternal.get(idx).id;
+        notesModelInternal.remove(idx);
+        if (root.activeId === removedId) {
+            if (notesModelInternal.count === 0)
+                root.activeId = "";
+            else
+                root.activeId = notesModelInternal.get(Math.min(idx, notesModelInternal.count - 1)).id;
+        }
+        root.persistNotes();
+    }
+
+    function deleteNoteById(id) {
+        let idx = root.indexOfId(id);
+        if (idx >= 0) root.deleteNoteAtIndex(idx);
+    }
+
+    function previewSnippet(content) {
+        if (!content || content.trim() === "")
+            return I18n.t("quickactions.notepad.tap_to_write");
+        let preview = root.stripMarkdown(content.replace(/\n/g, " ").trim());
+        return preview.length > 60 ? preview.substring(0, 60) + "…" : preview;
+    }
+}

--- a/src/scripts/notepad/md_render.py
+++ b/src/scripts/notepad/md_render.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Stdlib-only markdown -> HTML for Serpantinum notepad preview."""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+import sys
+from typing import List, Optional
+
+
+def color_to_css(value: str, fallback: str) -> str:
+    if not value or not isinstance(value, str):
+        return fallback
+    value = value.strip()
+    if value.startswith("#"):
+        return value
+    return fallback
+
+
+def build_css(theme: dict) -> str:
+    text = color_to_css(theme.get("text"), "#cdd6f4")
+    base = color_to_css(theme.get("base"), "#1e1e2e")
+    mantle = color_to_css(theme.get("mantle"), "#181825")
+    mauve = color_to_css(theme.get("mauve"), "#cba6f7")
+    surface0 = color_to_css(theme.get("surface0"), "#313244")
+    subtext0 = color_to_css(theme.get("subtext0"), "#a6adc8")
+    font = theme.get("fontFamily") or "sans-serif"
+    if "," in font:
+        font = font.split(",")[0].strip().strip("'\"")
+    return f"""
+    body {{
+        margin: 0;
+        padding: 4px 2px 12px 2px;
+        color: {text};
+        background: {base};
+        font-family: '{font}', sans-serif;
+        font-size: 13px;
+        line-height: 1.55;
+        word-wrap: break-word;
+    }}
+    h1, h2, h3, h4, h5, h6 {{
+        color: {text};
+        font-weight: 700;
+        line-height: 1.25;
+        margin: 0.85em 0 0.35em 0;
+    }}
+    h1 {{ font-size: 1.55em; border-bottom: 1px solid {surface0}; padding-bottom: 0.2em; }}
+    h2 {{ font-size: 1.35em; }}
+    h3 {{ font-size: 1.15em; color: {mauve}; }}
+    h4, h5, h6 {{ font-size: 1em; color: {subtext0}; }}
+    p {{ margin: 0.45em 0; }}
+    a {{ color: {mauve}; text-decoration: none; }}
+    a:hover {{ text-decoration: underline; }}
+    strong {{ font-weight: 700; color: {text}; }}
+    em {{ font-style: italic; }}
+    code {{
+        font-family: 'JetBrains Mono', monospace;
+        font-size: 0.9em;
+        background: {surface0};
+        color: {mauve};
+        padding: 0.12em 0.35em;
+        border-radius: 4px;
+    }}
+    pre {{
+        background: {mantle};
+        border: 1px solid {surface0};
+        border-radius: 8px;
+        padding: 10px 12px;
+        overflow-x: auto;
+        margin: 0.6em 0;
+    }}
+    pre code {{
+        background: transparent;
+        color: {text};
+        padding: 0;
+        border-radius: 0;
+        font-size: 0.85em;
+    }}
+    blockquote {{
+        margin: 0.5em 0;
+        padding: 0.25em 0 0.25em 12px;
+        border-left: 3px solid {mauve};
+        color: {subtext0};
+    }}
+    ul, ol {{ margin: 0.35em 0; padding-left: 1.35em; }}
+    li {{ margin: 0.15em 0; }}
+    li.task {{ list-style: none; margin-left: -1.35em; }}
+    hr {{
+        border: none;
+        border-top: 1px solid {surface0};
+        margin: 0.85em 0;
+    }}
+    .empty {{
+        color: {subtext0};
+        font-style: italic;
+        opacity: 0.75;
+    }}
+    """
+
+
+def render_inline(text: str) -> str:
+    if not text:
+        return ""
+
+    placeholders: List[str] = []
+
+    def stash(match: re.Match) -> str:
+        placeholders.append(match.group(0))
+        return f"\x00{len(placeholders) - 1}\x00"
+
+    # Fenced inline code already handled at block level; protect inline code
+    text = re.sub(r"`([^`\n]+)`", lambda m: stash(m), text)
+
+    escaped = html.escape(text, quote=True)
+
+    # Restore code spans
+    for i, raw in enumerate(placeholders):
+        inner = raw[1:-1]  # strip backticks
+        escaped = escaped.replace(f"\x00{i}\x00", f"<code>{html.escape(inner, quote=True)}</code>")
+
+    # Links [text](url)
+    escaped = re.sub(
+        r"\[([^\]]+)\]\(([^)]+)\)",
+        lambda m: f'<a href="{html.escape(m.group(2), quote=True)}">{html.escape(m.group(1), quote=True)}</a>',
+        escaped,
+    )
+
+    # Bold / italic
+    escaped = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", escaped)
+    escaped = re.sub(r"__(.+?)__", r"<strong>\1</strong>", escaped)
+    escaped = re.sub(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)", r"<em>\1</em>", escaped)
+    escaped = re.sub(r"(?<!_)_(?!_)(.+?)(?<!_)_(?!_)", r"<em>\1</em>", escaped)
+    escaped = re.sub(r"~~(.+?)~~", r"<del>\1</del>", escaped)
+
+    return escaped
+
+
+def parse_blocks(source: str) -> List[str]:
+    lines = source.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    blocks: List[str] = []
+    i = 0
+    n = len(lines)
+
+    def is_blank(line: str) -> bool:
+        return line.strip() == ""
+
+    while i < n:
+        line = lines[i]
+
+        if is_blank(line):
+            i += 1
+            continue
+
+        # Fenced code block
+        fence = re.match(r"^(`{3,}|~{3,})(\w*)?\s*$", line.strip())
+        if fence:
+            marker = fence.group(1)[0]
+            lang = fence.group(2) or ""
+            i += 1
+            code_lines: List[str] = []
+            while i < n and not lines[i].strip().startswith(marker * 3):
+                code_lines.append(lines[i])
+                i += 1
+            if i < n:
+                i += 1
+            code_html = html.escape("\n".join(code_lines), quote=False)
+            lang_attr = f' class="language-{html.escape(lang, quote=True)}"' if lang else ""
+            blocks.append(f"<pre><code{lang_attr}>{code_html}</code></pre>")
+            continue
+
+        # Heading
+        heading = re.match(r"^(#{1,6})\s+(.+)$", line)
+        if heading:
+            level = len(heading.group(1))
+            blocks.append(f"<h{level}>{render_inline(heading.group(2))}</h{level}>")
+            i += 1
+            continue
+
+        # HR
+        if re.match(r"^(-{3,}|\*{3,}|_{3,})\s*$", line.strip()):
+            blocks.append("<hr/>")
+            i += 1
+            continue
+
+        # Blockquote
+        if line.lstrip().startswith(">"):
+            quote_lines: List[str] = []
+            while i < n and lines[i].lstrip().startswith(">"):
+                quote_lines.append(re.sub(r"^\s*>\s?", "", lines[i]))
+                i += 1
+            inner = "<br/>".join(render_inline(l) for l in quote_lines if l.strip() != "")
+            blocks.append(f"<blockquote><p>{inner}</p></blockquote>")
+            continue
+
+        # Task list
+        task = re.match(r"^(\s*)[-*+]\s+\[([ xX])\]\s+(.+)$", line)
+        if task:
+            items: List[str] = []
+            while i < n:
+                m = re.match(r"^(\s*)[-*+]\s+\[([ xX])\]\s+(.+)$", lines[i])
+                if not m:
+                    break
+                checked = m.group(2).lower() == "x"
+                mark = "☑" if checked else "☐"
+                items.append(
+                    f'<li class="task">{mark} {render_inline(m.group(3))}</li>'
+                )
+                i += 1
+            blocks.append(f"<ul>{''.join(items)}</ul>")
+            continue
+
+        # Unordered list
+        if re.match(r"^\s*[-*+]\s+", line):
+            items = []
+            while i < n and re.match(r"^\s*[-*+]\s+", lines[i]):
+                item = re.sub(r"^\s*[-*+]\s+", "", lines[i])
+                items.append(f"<li>{render_inline(item)}</li>")
+                i += 1
+            blocks.append(f"<ul>{''.join(items)}</ul>")
+            continue
+
+        # Ordered list
+        if re.match(r"^\s*\d+\.\s+", line):
+            items = []
+            while i < n and re.match(r"^\s*\d+\.\s+", lines[i]):
+                item = re.sub(r"^\s*\d+\.\s+", "", lines[i])
+                items.append(f"<li>{render_inline(item)}</li>")
+                i += 1
+            blocks.append(f"<ol>{''.join(items)}</ol>")
+            continue
+
+        # Paragraph
+        para_lines: List[str] = []
+        while i < n and not is_blank(lines[i]):
+            if re.match(r"^(#{1,6})\s+", lines[i]):
+                break
+            if re.match(r"^(`{3,}|~{3,})", lines[i].strip()):
+                break
+            if lines[i].lstrip().startswith(">"):
+                break
+            if re.match(r"^\s*[-*+]\s+", lines[i]) or re.match(r"^\s*\d+\.\s+", lines[i]):
+                break
+            para_lines.append(lines[i])
+            i += 1
+        if para_lines:
+            joined = " ".join(l.strip() for l in para_lines)
+            blocks.append(f"<p>{render_inline(joined)}</p>")
+
+    return blocks
+
+
+def render_document(markdown: str, theme: dict, empty_hint: str = "") -> str:
+    css = build_css(theme)
+    body = markdown or ""
+    if not body.strip():
+        content = f'<p class="empty">{html.escape(empty_hint or "Empty note", quote=True)}</p>'
+    else:
+        blocks = parse_blocks(body)
+        content = "".join(blocks) if blocks else f"<p>{render_inline(body)}</p>"
+    return f"<!DOCTYPE html><html><head><meta charset='utf-8'><style>{css}</style></head><body>{content}</body></html>"
+
+
+def main() -> int:
+    try:
+        if len(sys.argv) > 1:
+            with open(sys.argv[1], encoding="utf-8") as f:
+                raw = f.read()
+        else:
+            raw = sys.stdin.read()
+        payload = json.loads(raw or "{}")
+        markdown = payload.get("markdown", "")
+        theme = payload.get("theme") or {}
+        empty_hint = payload.get("emptyHint", "")
+        sys.stdout.write(render_document(markdown, theme, empty_hint))
+        return 0
+    except Exception as exc:
+        sys.stderr.write(str(exc) + "\n")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Notepad for Quick Actions (v2)

I use a notepad all day — quick bits of text, ideas, things I need to remember. Building on the great work from #194 (thanks @JuManoel!), this PR keeps the idea and applies the review feedback while keeping it simple and functional.

### What's in

- **Notes tab in Quick Actions**: create, list, rename, edit and delete notes
- **Markdown preview** rendered by a tiny stdlib-only Python helper (no new deps)
- **Persistent**: notes live in `~/.local/state/serpantinum/notepad/notes.json`
- **Derived titles**: notes without a title show the first line as a placeholder — click the title to rename
- **Keeps itself open** while you're editing or renaming (`keepAlive`), and closes as usual otherwise
- **Panel grows with the text**: starts compact and expands as you type past the bottom
- **Scrolling inside the panel scrolls the content** — the wheel no longer switches tabs (this also fixes scrolling for any scrollable action)

### Screenshots

1. Notes list, with derived titles and per-note previews:

![notes list](https://raw.githubusercontent.com/stoltembergg-png/serpantinum/084d7ca49f3bbb4c8c974ca231eb22a606c0c446/docs/notepad/notepad-01-list.png)

2. New note (empty state):

![new note](https://raw.githubusercontent.com/stoltembergg-png/serpantinum/084d7ca49f3bbb4c8c974ca231eb22a606c0c446/docs/notepad/notepad-02-new.png)

3. Editing (markdown source):

![editing](https://raw.githubusercontent.com/stoltembergg-png/serpantinum/084d7ca49f3bbb4c8c974ca231eb22a606c0c446/docs/notepad/notepad-03-edit.png)

4. Preview (rendered markdown):

![preview](https://raw.githubusercontent.com/stoltembergg-png/serpantinum/084d7ca49f3bbb4c8c974ca231eb22a606c0c446/docs/notepad/notepad-04-preview.png)

5. Untitled note → title derived from the first line:

![derived title](https://raw.githubusercontent.com/stoltembergg-png/serpantinum/084d7ca49f3bbb4c8c974ca231eb22a606c0c446/docs/notepad/notepad-05-derived-title.png)

### Notes

- Tested on CachyOS (Hyprland, bar on top).
- No runtime dependencies added: `python3` stdlib only.
- Existing quick actions are untouched; the only shared change is the panel scroll behavior described above.
