### PR TITLE
feat: normalize audio device names in the volume popup

### DIFF
--- a/src/assets/languages/en.json
+++ b/src/assets/languages/en.json
@@ -853,6 +853,8 @@
     "master_output_volume": "Master output volume",
     "no_active_streams": "No active streams",
     "active_default": "Active default",
+      "internal_audio": "Internal audio",
+      "analog": "Analog",
     "tabs": {
       "outputs": "Outputs",
       "inputs": "Inputs",

--- a/src/assets/languages/es.json
+++ b/src/assets/languages/es.json
@@ -897,6 +897,8 @@
     "master_output_volume": "Volumen de salida principal",
     "no_active_streams": "Sin transmisiones activas",
     "active_default": "Predeterminado activo",
+      "internal_audio": "Audio integrado",
+      "analog": "Analógico",
     "tabs": {
       "outputs": "Salidas",
       "inputs": "Entradas",

--- a/src/assets/languages/pt.json
+++ b/src/assets/languages/pt.json
@@ -853,6 +853,8 @@
     "master_output_volume": "Volume principal de saída",
     "no_active_streams": "Nenhum fluxo ativo",
     "active_default": "Padrão ativo",
+      "internal_audio": "Áudio integrado",
+      "analog": "Analógico",
     "tabs": {
       "outputs": "Saídas",
       "inputs": "Entradas",

--- a/src/quickshell/singletons/audio/Audio.qml
+++ b/src/quickshell/singletons/audio/Audio.qml
@@ -2,6 +2,7 @@ pragma Singleton
 import QtQuick
 import Quickshell
 import Quickshell.Services.Pipewire
+import "../../"
 
 Singleton {
     id: root
@@ -60,9 +61,90 @@ Singleton {
         if (node && node.audio) node.audio.volume = Math.max(0, Math.min(1.5, pct / 100.0));
     }
 
+    // ---------- name normalization ----------
+
+    function profileDescription(node) {
+        return (node && node.properties) ? (node.properties["device.profile.description"] || "") : "";
+    }
+
+    function regexEscape(s) {
+        return String(s).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    }
+
+    function stripProfile(text, profile) {
+        if (!text) return "";
+        let out = String(text);
+        if (profile) out = out.replace(new RegExp(regexEscape(profile), "i"), " ");
+        return out.trim();
+    }
+
+    function cleanNamePart(s) {
+        if (!s) return "";
+        let out = String(s);
+        out = out.replace(/\s*\[[^\]]*\]\s*/g, " "); // [vendor/model] noise
+        out = out.replace(/\bHD Audio Controller\b/gi, "HD Audio");
+        out = out.replace(/\bAudio Controller\b/gi, "Audio");
+        out = out.replace(/\s*[-–—·:]\s*$/g, "");
+        out = out.replace(/\s{2,}/g, " ").trim();
+        return out;
+    }
+
+    function looksLikeCode(s) {
+        if (!s) return true;
+        return !/[a-z]/.test(s);
+    }
+
+    function friendlyLabelFor(text, profile) {
+        const prof = (profile || "").toLowerCase();
+        const hay = (text || "").toLowerCase();
+        if (/displayport|\bdp\b/.test(prof)) return "DisplayPort (GPU)";
+        if (/hdmi/.test(prof)) return "HDMI (GPU)";
+        if (/displayport|\bdp\b/.test(hay)) return "DisplayPort (GPU)";
+        if (/hdmi/.test(hay)) return "HDMI (GPU)";
+        if (/hd audio|audio controller|built-in audio|renoir|cezanne|family \w+/.test(hay))
+            return I18n.t("volumepopup.internal_audio");
+        return text;
+    }
+
+    function normalizedDeviceName(node) {
+        const props = (node && node.properties) ? node.properties : {};
+        const profile = profileDescription(node);
+        const deviceDesc = props["device.description"] || "";
+        const nodeDesc = node ? (node.description || "") : "";
+        const nick = props["device.nick"] || (node ? (node.nick || "") : "");
+
+        let base = cleanNamePart(stripProfile(deviceDesc, profile));
+        if (!base) base = cleanNamePart(stripProfile(nodeDesc, profile));
+        if (base) return friendlyLabelFor(base, profile);
+
+        let short = cleanNamePart(nick);
+        if (short && !looksLikeCode(short)) return friendlyLabelFor(short, profile);
+
+        return cleanNamePart(nick || (node ? node.name : "") || "") || "Unknown Device";
+    }
+
+    function profileLabel(node) {
+        const profile = profileDescription(node);
+        if (!profile) return "";
+        const hdmi = profile.match(/HDMI\s*(\d*)/i);
+        if (hdmi) return "HDMI" + (hdmi[1] ? " " + hdmi[1] : "");
+        if (/anal[oó]gic/i.test(profile)) return I18n.t("volumepopup.analog");
+        if (/\bdigital\b/i.test(profile)) return "Digital";
+        if (/\bmono\b/i.test(profile)) return "Mono";
+        return profile;
+    }
+
     function getNodeName(node) {
         if (!node) return "";
-        return node.properties?.["device.description"] || node.description || node.name || "Unknown Device";
+        // Handle virtual devices (easyeffects, pipewire, etc.) with cleaner names
+        const nodeName = node.name || "";
+        if (nodeName.startsWith("easyeffects_")) {
+            return "Easy Effects";
+        }
+        if (nodeName.startsWith("pipewire_")) {
+            return "PipeWire";
+        }
+        return normalizedDeviceName(node);
     }
 
     function getNodeSubDesc(node) {
@@ -70,7 +152,24 @@ Singleton {
         if (node.isStream) {
             return node.properties?.["media.name"] || node.properties?.["window.title"] || node.properties?.["media.role"] || "Audio Stream";
         }
-        return node.name || "Unknown";
+        // For device nodes, show a cleaned-up profile/description
+        const profile = profileDescription(node);
+        const devName = node.properties?.["device.name"] || "";
+        const api = node.properties?.["api.alsa.path"] || "";
+        if (profile) return profileLabel(node);
+        if (devName) return cleanNamePart(devName.replace(/^alsa_/, ""));
+        if (api) return api;
+        
+        // For virtual nodes (easyeffects, etc.) show a clean type instead of internal name
+        const nodeName = node.name || "";
+        if (nodeName.startsWith("easyeffects_")) {
+            return nodeName.includes("sink") ? "Saída virtual" : "Entrada virtual";
+        }
+        if (nodeName.startsWith("pipewire_")) {
+            return "Virtual";
+        }
+        
+        return cleanNamePart(node.nick || node.name || "") || "Unknown";
     }
 
     function getNodeAppName(node) {


### PR DESCRIPTION
## Normalize audio device names in the volume popup

Device names in the volume popup come straight from PipeWire/ALSA, and depending on the hardware they end up inconsistent: some show codec or monitor codes (`ALC897 Analog`, `PEGASIPROUW29`), others concatenate the localized profile description (`... Estéreo analógico`).

This PR normalizes what is displayed, without changing any behavior:

- **Name**: built from `device.description` with the profile description removed, then cleaned (drops `[vendor/model]` noise, shortens `Audio Controller` → `Audio`)
- **Friendly labels**: internal codecs → *Internal audio*; HDMI/DisplayPort → `HDMI (GPU)` / `DisplayPort (GPU)`
- **Nick fallback** only when it looks like a readable name (skips codes like `PEGASIPROUW29`)
- **Subtitle**: friendly profile → `HDMI 5`, `Analog`, `Digital`, `Mono`
- Virtual devices (Easy Effects/PipeWire) and app/stream names are untouched

### Before / after (real devices)

| Before | After |
|---|---|
| `ALC897 Analog` · `Estéreo analógico` | `Áudio integrado` · `Analógico` |
| `PEGASIPROUW29` · `Digital Stereo (HDMI 5)` | `HDMI (GPU)` · `HDMI 5` |
| `H510-PRO Wireless headset` · `Estéreo analógico` | `H510-PRO Wireless headset` · `Analógico` |

### Notes

- Tested on CachyOS/Hyprland (PipeWire/WirePlumber).
- i18n: added `volumepopup.analog` and `volumepopup.internal_audio` (en/es/pt).
- No functional change: device selection, volume and mute logic are untouched.
