### PR TITLE
fix(sddm): configure explicit compositor command for wayland and safe fallbacks

### DIFF
--- a/install/modules/deploy.sh
+++ b/install/modules/deploy.sh
@@ -125,6 +125,46 @@ install_wallpapers() {
     fi
 }
 
+resolve_sddm_backend() {
+    local requested_wayland="${1:-false}"
+    local server="x11"
+    local compositor_cmd=""
+
+    if [ "$requested_wayland" = true ]; then
+        if command -v kwin_wayland &>/dev/null; then
+            server="wayland"
+            compositor_cmd="kwin_wayland --no-global-shortcuts --no-lockscreen --locale1"
+        elif command -v weston &>/dev/null; then
+            server="wayland"
+            compositor_cmd="weston --shell=kiosk"
+        elif command -v Xorg &>/dev/null || command -v X &>/dev/null; then
+            echo -e "  \e[33m[ WARN ]\e[0m No supported Wayland greeter compositor found (kwin_wayland/weston); falling back to X11 for SDDM." >&2
+            server="x11"
+        else
+            echo -e "  \e[31m[ ERROR ]\e[0m Neither a supported Wayland greeter compositor (kwin_wayland/weston) nor Xorg was found." >&2
+            return 1
+        fi
+    else
+        if command -v Xorg &>/dev/null || command -v X &>/dev/null; then
+            server="x11"
+        elif command -v kwin_wayland &>/dev/null; then
+            echo -e "  \e[33m[ WARN ]\e[0m Xorg not found; using kwin_wayland for SDDM." >&2
+            server="wayland"
+            compositor_cmd="kwin_wayland --no-global-shortcuts --no-lockscreen --locale1"
+        elif command -v weston &>/dev/null; then
+            echo -e "  \e[33m[ WARN ]\e[0m Xorg not found; using weston for SDDM." >&2
+            server="wayland"
+            compositor_cmd="weston --shell=kiosk"
+        else
+            echo -e "  \e[31m[ ERROR ]\e[0m Neither Xorg nor a supported Wayland greeter compositor (kwin_wayland/weston) was found." >&2
+            return 1
+        fi
+    fi
+
+    echo "$server"
+    echo "$compositor_cmd"
+}
+
 setup_sddm() {
     local project_root="$1"
     local install_state="${2:-$INSTALL_STATE}"
@@ -185,9 +225,22 @@ setup_sddm() {
         fi
     fi
 
+    local sddm_display_server=""
+    local sddm_compositor_cmd=""
+    local backend_output=""
+    if ! backend_output=$(resolve_sddm_backend "$SDDM_WAYLAND"); then
+        echo -e "  \e[31m[ ERROR ]\e[0m Skipping SDDM configuration: no usable display server or greeter compositor found." >&2
+        return 0
+    fi
+
+    {
+        read -r sddm_display_server
+        read -r sddm_compositor_cmd
+    } <<< "$backend_output"
+
     sudo mkdir -p /etc/sddm.conf.d
 
-    if [ "$SDDM_WAYLAND" = true ]; then
+    if [ "$sddm_display_server" = "wayland" ]; then
         cat <<EOF | sudo tee /etc/sddm.conf.d/10-material-you.conf > /dev/null
 [Theme]
 Current=material-you
@@ -197,6 +250,9 @@ ThemeDir=/usr/share/sddm/themes
 DisplayServer=wayland
 GreeterEnvironment=QT_WAYLAND_DISABLE_WINDOWDECORATION=1
 InputMethod=
+
+[Wayland]
+CompositorCommand=$sddm_compositor_cmd
 EOF
     else
         cat <<EOF | sudo tee /etc/sddm.conf.d/10-material-you.conf > /dev/null
@@ -205,6 +261,7 @@ Current=material-you
 ThemeDir=/usr/share/sddm/themes
 
 [General]
+DisplayServer=x11
 InputMethod=
 EOF
     fi

--- a/install/modules/deploy.sh
+++ b/install/modules/deploy.sh
@@ -174,6 +174,19 @@ setup_sddm() {
         return 0
     fi
 
+    local sddm_display_server=""
+    local sddm_compositor_cmd=""
+    local backend_output=""
+    if ! backend_output=$(resolve_sddm_backend "$SDDM_WAYLAND"); then
+        echo -e "  \e[31m[ ERROR ]\e[0m Cannot configure SDDM: no usable display server or greeter compositor found." >&2
+        return 1
+    fi
+
+    {
+        read -r sddm_display_server
+        read -r sddm_compositor_cmd
+    } <<< "$backend_output"
+
     local is_update=false
     if [[ "$install_state" == "current" && "$is_reinstall" != "true" ]]; then
         is_update=true
@@ -224,19 +237,6 @@ setup_sddm() {
             fc-cache -f /usr/share/fonts >/dev/null 2>&1 || true
         fi
     fi
-
-    local sddm_display_server=""
-    local sddm_compositor_cmd=""
-    local backend_output=""
-    if ! backend_output=$(resolve_sddm_backend "$SDDM_WAYLAND"); then
-        echo -e "  \e[31m[ ERROR ]\e[0m Skipping SDDM configuration: no usable display server or greeter compositor found." >&2
-        return 0
-    fi
-
-    {
-        read -r sddm_display_server
-        read -r sddm_compositor_cmd
-    } <<< "$backend_output"
 
     sudo mkdir -p /etc/sddm.conf.d
 

--- a/install/modules/deps.sh
+++ b/install/modules/deps.sh
@@ -180,6 +180,9 @@ install_dependencies() {
 
     if [ "$OPT_SDDM" = true ]; then
         target_list+=("sddm" "qt6-declarative" "qt6-svg")
+        if [ "$SDDM_WAYLAND" = true ] && ! command -v kwin_wayland &>/dev/null && ! command -v weston &>/dev/null; then
+            target_list+=("weston")
+        fi
     fi
 
     echo -e "\n\e[36m[ INFO ]\e[0m $(t "installer.deps.syncing")"

--- a/tests/test-sddm-backend.sh
+++ b/tests/test-sddm-backend.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+eval "$(sed -n '/^resolve_sddm_backend()/,/^}/p' "$REPO_ROOT/install/modules/deploy.sh")"
+
+pass_count=0
+fail_count=0
+
+run_test() {
+    local name="$1"
+    local wayland_flag="$2"
+    local expected_srv="$3"
+    local expected_cmd="$4"
+    shift 4
+    local mock_binaries=("$@")
+
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+    for bin in "${mock_binaries[@]}"; do
+        touch "$tmpdir/$bin"
+        chmod +x "$tmpdir/$bin"
+    done
+
+    local srv="" cmd=""
+    local output=""
+    if output=$(PATH="$tmpdir" resolve_sddm_backend "$wayland_flag" 2>/dev/null); then
+        {
+            read -r srv || true
+            read -r cmd || true
+        } <<< "$output"
+    fi
+
+    rm -rf "$tmpdir"
+
+    if [[ "$srv" == "$expected_srv" && "$cmd" == "$expected_cmd" ]]; then
+        printf "  \e[32m✔ PASS\e[0m: %s\n" "$name"
+        pass_count=$((pass_count + 1))
+    else
+        printf "  \e[31m✘ FAIL\e[0m: %s\n" "$name"
+        printf "      Expected: server='%s' cmd='%s'\n" "$expected_srv" "$expected_cmd"
+        printf "      Got:      server='%s' cmd='%s'\n" "$srv" "$cmd"
+        fail_count=$((fail_count + 1))
+    fi
+}
+
+run_fail_test() {
+    local name="$1"
+    local wayland_flag="$2"
+    shift 2
+    local mock_binaries=("$@")
+
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+    for bin in "${mock_binaries[@]}"; do
+        touch "$tmpdir/$bin"
+        chmod +x "$tmpdir/$bin"
+    done
+
+    if PATH="$tmpdir" resolve_sddm_backend "$wayland_flag" >/dev/null 2>&1; then
+        printf "  \e[31m✘ FAIL\e[0m: %s (expected failure, but succeeded)\n" "$name"
+        fail_count=$((fail_count + 1))
+    else
+        printf "  \e[32m✔ PASS\e[0m: %s\n" "$name"
+        pass_count=$((pass_count + 1))
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+echo "Running SDDM backend resolution tests..."
+
+run_test "Wayland requested with kwin_wayland" \
+    true "wayland" "kwin_wayland --no-global-shortcuts --no-lockscreen --locale1" \
+    "kwin_wayland"
+
+run_test "Wayland requested with weston" \
+    true "wayland" "weston --shell=kiosk" \
+    "weston"
+
+run_test "Wayland requested with both kwin and weston (prefers kwin)" \
+    true "wayland" "kwin_wayland --no-global-shortcuts --no-lockscreen --locale1" \
+    "kwin_wayland" "weston"
+
+run_test "Wayland requested without Wayland compositor (fallback to Xorg)" \
+    true "x11" "" \
+    "Xorg"
+
+run_fail_test "Wayland requested with neither Wayland compositor nor Xorg (returns error)" \
+    true
+
+run_test "X11 requested with Xorg" \
+    false "x11" "" \
+    "Xorg"
+
+run_test "X11 requested without Xorg (fallback to kwin_wayland)" \
+    false "wayland" "kwin_wayland --no-global-shortcuts --no-lockscreen --locale1" \
+    "kwin_wayland"
+
+run_test "X11 requested without Xorg (fallback to weston)" \
+    false "wayland" "weston --shell=kiosk" \
+    "weston"
+
+run_fail_test "X11 requested with nothing available (returns error)" \
+    false
+
+echo "--------------------------------------------------"
+echo "Tests completed: $pass_count passed, $fail_count failed"
+
+if [[ "$fail_count" -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## What this fixes

When choosing SDDM with Wayland (`SDDM_WAYLAND=true`), the installer writes `DisplayServer=wayland` into `/etc/sddm.conf.d/10-material-you.conf`, but doesn't set a compositor command under `[Wayland]`.

By default, SDDM tries to execute `weston --shell=kiosk`. On minimal or standalone Hyprland installs (like on CachyOS or Arch), Weston isn't installed. This causes SDDM to crash-loop trying to launch a missing compositor, freezing the screen and locking the TTY on boot.

## What this PR does

Instead of trying to hack compositor GPU configs in bash (which Hyprland and Niri already handle on their own), this focuses purely on making the SDDM setup reliable:

1. **Explicit Compositor Command**: Added `resolve_sddm_backend()` in `deploy.sh` to check for `kwin_wayland` or `weston` and write the exact `[Wayland] CompositorCommand`:
   - `kwin_wayland --no-global-shortcuts --no-lockscreen --locale1`
   - `weston --shell=kiosk`
2. **Pre-flight Check**: Moves backend resolution to the very top of `setup_sddm()`. If no usable display backend is found, it aborts before disabling/removing existing display managers or touching configs.
3. **Dependency Sync**: In `deps.sh`, if Wayland SDDM is enabled and neither KWin nor Weston is found, it automatically includes `weston` in the package list so it gets installed during setup.
4. **Safe Fallback**: If Wayland was selected but no Wayland greeter is available, it falls back to X11 (if Xorg exists). If X11 was chosen but only a Wayland greeter is installed, it uses that instead of failing.
5. **Unit Tests**: Added `tests/test-sddm-backend.sh` testing all 9 resolution permutations (both Wayland and X11 requested across KWin, Weston, Xorg, fallbacks, and missing backends).

Tested locally with `bash tests/test-sddm-backend.sh` (9/9 pass).