### PR TITLE
feat: add support for NVIDIA offloading based on connected displays

### DIFF
--- a/bin/serpantinumd
+++ b/bin/serpantinumd
@@ -311,14 +311,17 @@ if [ "$COMMAND" == "start" ]; then
 
     EGL_NVIDIA_JSON=$(find /usr/share/glvnd/egl_vendor.d/ -iname "*nvidia*.json" 2>/dev/null | head -n1)
 
-    if gpu_display_connected && has_nvidia && [ -n "$EGL_NVIDIA_JSON" ]; then
-        echo "External display + NVIDIA detected → offloading Quickshell"
-        __NV_PRIME_RENDER_OFFLOAD=1 \
-        __NV_PRIME_RENDER_OFFLOAD_PROVIDER=NVIDIA-G0 \
-        __EGL_VENDOR_LIBRARY_FILENAMES="$EGL_NVIDIA_JSON" \
-        quickshell -p "$MAIN_QML" 9>&- &
+    if [ "${GPU_AUTO_SWITCH_EXTERNAL_DISPLAY:-false}" = "true" ] && gpu_display_connected && has_nvidia; then
+        EGL_NVIDIA_JSON=$(find /usr/share/glvnd/egl_vendor.d/ /run/opengl-driver/share/glvnd/egl_vendor.d/ -iname "*nvidia*.json" 2>/dev/null | head -n1)
+        if [ -n "$EGL_NVIDIA_JSON" ]; then
+            __NV_PRIME_RENDER_OFFLOAD=1 \
+            __NV_PRIME_RENDER_OFFLOAD_PROVIDER=NVIDIA-G0 \
+            __EGL_VENDOR_LIBRARY_FILENAMES="$EGL_NVIDIA_JSON" \
+            quickshell -p "$MAIN_QML" 9>&- &
+        else
+            quickshell -p "$MAIN_QML" 9>&- &
+        fi
     else
-        echo "Starting Quickshell normally"
         quickshell -p "$MAIN_QML" 9>&- &
     fi
 

--- a/bin/serpantinumd
+++ b/bin/serpantinumd
@@ -309,9 +309,7 @@ if [ "$COMMAND" == "start" ]; then
         command -v nvidia-smi &>/dev/null && nvidia-smi &>/dev/null
     }
 
-    EGL_NVIDIA_JSON=$(find /usr/share/glvnd/egl_vendor.d/ -iname "*nvidia*.json" 2>/dev/null | head -n1)
-
-    if [ "${GPU_AUTO_SWITCH_EXTERNAL_DISPLAY:-false}" = "true" ] && gpu_display_connected && has_nvidia; then
+   if [ "${GPU_AUTO_SWITCH_EXTERNAL_DISPLAY:-false}" = "true" ] && gpu_display_connected && has_nvidia; then
         EGL_NVIDIA_JSON=$(find /usr/share/glvnd/egl_vendor.d/ /run/opengl-driver/share/glvnd/egl_vendor.d/ -iname "*nvidia*.json" 2>/dev/null | head -n1)
         if [ -n "$EGL_NVIDIA_JSON" ]; then
             __NV_PRIME_RENDER_OFFLOAD=1 \

--- a/bin/serpantinumd
+++ b/bin/serpantinumd
@@ -293,8 +293,37 @@ if [ "$COMMAND" == "start" ]; then
     bash "$SERPANTINUM_DIR/quickshell/guide/wellbeing/launch_daemon.sh" 9>&- &
     LAUNCH_PID=$!
 
-    quickshell -p "$MAIN_QML" 9>&- &
+    # Dynamically find any connected HDMI/DP output across all cards
+    gpu_display_connected() {
+        for status_file in /sys/class/drm/card*-{HDMI,DP}-*/status; do
+            [ -f "$status_file" ] || continue
+            if [ "$(cat "$status_file" 2>/dev/null)" = "connected" ]; then
+                return 0
+            fi
+        done
+        return 1
+    }
+
+    # Only attempt NVIDIA offload if the hardware/driver actually exists
+    has_nvidia() {
+        command -v nvidia-smi &>/dev/null && nvidia-smi &>/dev/null
+    }
+
+    EGL_NVIDIA_JSON=$(find /usr/share/glvnd/egl_vendor.d/ -iname "*nvidia*.json" 2>/dev/null | head -n1)
+
+    if gpu_display_connected && has_nvidia && [ -n "$EGL_NVIDIA_JSON" ]; then
+        echo "External display + NVIDIA detected → offloading Quickshell"
+        __NV_PRIME_RENDER_OFFLOAD=1 \
+        __NV_PRIME_RENDER_OFFLOAD_PROVIDER=NVIDIA-G0 \
+        __EGL_VENDOR_LIBRARY_FILENAMES="$EGL_NVIDIA_JSON" \
+        quickshell -p "$MAIN_QML" 9>&- &
+    else
+        echo "Starting Quickshell normally"
+        quickshell -p "$MAIN_QML" 9>&- &
+    fi
+
     QS_PID=$!
+    CHILD_PIDS+=($QS_PID)
 
     wait $QS_PID
 fi


### PR DESCRIPTION
## Problem
On Optimus laptops where the HDMI/DisplayPort output is physically wired to the 
discrete NVIDIA GPU (common wiring on many laptop models), Quickshell fails to 
appear on the external display when rendering via the Intel iGPU only — since 
Intel has no path to that output.

## Solution
Adds an opt-in config option that detects a connected external display and, 
if present, launches Quickshell with NVIDIA PRIME render offload so it can 
actually output to that port. Falls back to normal rendering when:
- No external display is connected
- No NVIDIA GPU/driver is present (AMD, Intel-only, etc.)

## Why opt-in, not default
Testing showed PRIME offload introduces noticeable input latency for bar/widget 
interactions (see #145) due to the render-to-display copy-back over PCIe on 
Optimus setups. Most users on laptop-only setups should keep the default 
Intel rendering path for responsiveness. This is only useful for the specific 
case of HDMI-out wired to the dGPU.

## Testing
Tested on Lenovo Rescuer-15ISK with GTX 960M + Intel iGPU, confirmed:
- Quickshell renders correctly on external HDMI display when NVIDIA offload triggers
- Falls back correctly to Intel when HDMI disconnected
- No behavior change for AMD/Intel-only systems (offload skipped safely)