### PR TITLE
feat: fingerprint unlock on the lock screen

### DIFF
--- a/config/serpantinum/settings.json
+++ b/config/serpantinum/settings.json
@@ -103,6 +103,10 @@
     "sound": true,
     "soundFile": ""
   },
+  "lock": {
+    "fingerprint": true,
+    "fingerprintTries": 3
+  },
   "display": {
     "monitors": {
       "eDP-1": {

--- a/nix/settings-options.nix
+++ b/nix/settings-options.nix
@@ -114,6 +114,11 @@ let
     temperature = mkOpt types.int "Colour-temperature override for this output (units depend on how src/scripts drives wl-gammarelay-rs - check there if unsure).";
   };
 
+  lockSubmodule = freeform {
+    fingerprint = mkOpt types.bool "Unlock with an enrolled fingerprint (fprintd) while the password prompt is shown.";
+    fingerprintTries = mkOpt types.ints.positive "Failed fingerprint matches before the reader gives up for this lock.";
+  };
+
   displaySubmodule = freeform {
     monitors = mkOption {
       type = types.attrsOf monitorSubmodule;
@@ -129,6 +134,7 @@ in
     theme = mkOption { type = themeSubmodule; default = { }; };
     idle = mkOption { type = idleSubmodule; default = { }; };
     notifications = mkOption { type = notificationsSubmodule; default = { }; };
+    lock = mkOption { type = lockSubmodule; default = { }; };
     display = mkOption { type = displaySubmodule; default = { }; };
     wallpaperDir = mkOpt types.str ''
       Directory Serpantinum reads wallpapers from.

--- a/src/assets/languages/en.json
+++ b/src/assets/languages/en.json
@@ -659,7 +659,10 @@
       "locked": "Locked",
       "access_denied": "Access denied",
       "authenticating": "Authenticating...",
-      "enter_pin": "Enter PIN"
+      "enter_pin": "Enter PIN",
+      "fingerprint_prompt": "Touch the fingerprint sensor or enter PIN",
+      "fingerprint_retry": "Fingerprint not recognized ({tries}/{max}), try again",
+      "fingerprint_failed": "Too many fingerprint attempts, enter PIN"
     },
     "power": {
       "suspend": "Suspend",

--- a/src/quickshell/lock/Lock.qml
+++ b/src/quickshell/lock/Lock.qml
@@ -208,6 +208,8 @@ Scope {
         if (!rootLock.locked) return;
         rootLock.locked = false;
         root.isUnlocking = false;
+        fingerprint.abort();
+        if (pam.active) pam.abort();
         kbWaiter.running = false;
         kbPoller.running = false;
         if (root.freezeTimestamp !== "") {

--- a/src/quickshell/lock/Lock.qml
+++ b/src/quickshell/lock/Lock.qml
@@ -193,12 +193,15 @@ Scope {
         lockUI.statusText = I18n.t("lock.status.locked");
         rootLock.locked = true;
         pamActionTimer.start();
+        fingerprint.reset();
+        fingerprint.check();
         kbPollerRestartTimer.restart();
     }
 
     function finishUnlock() {
         if (root.isUnlocking) return;
         root.isUnlocking = true;
+        fingerprint.abort();
     }
 
     function completeUnlock() {
@@ -218,6 +221,9 @@ Scope {
         function activate(): void {
             root.lock();
         }
+        function isLocked(): bool {
+            return rootLock.locked;
+        }
     }
 
     Settings {
@@ -232,6 +238,106 @@ Scope {
         property bool failed: false
         property bool authenticating: false
         property string statusText: I18n.t("lock.status.locked")
+    }
+
+    QtObject {
+        id: fingerprint
+
+        readonly property var config: Config.getSetting("lock", { "fingerprint": true, "fingerprintTries": 3 })
+        readonly property bool enabled: config && config.fingerprint !== false
+        readonly property int maxTries: {
+            let n = parseInt(config ? config.fingerprintTries : 3);
+            return isNaN(n) || n < 1 ? 3 : n;
+        }
+        property bool available: false
+        property int tries: 0
+        property int errors: 0
+        readonly property bool canAttempt: enabled && available && rootLock.locked && !root.isUnlocking && tries < maxTries
+
+        function reset() {
+            tries = 0;
+            errors = 0;
+        }
+
+        function check() {
+            if (enabled) {
+                fingerprintAvailProcess.running = true;
+            } else {
+                available = false;
+            }
+        }
+
+        function start() {
+            if (!canAttempt || pamFingerprint.active) return;
+            pamFingerprint.start();
+        }
+
+        function abort() {
+            fingerprintRetryTimer.stop();
+            if (pamFingerprint.active) pamFingerprint.abort();
+        }
+
+        function setStatus(text) {
+            if (lockUI.authenticating || root.isUnlocking) return;
+            lockUI.statusText = text;
+        }
+    }
+
+    Process {
+        id: fingerprintAvailProcess
+        command: ["sh", "-c", "command -v fprintd-list >/dev/null 2>&1 && fprintd-list \"$(id -un)\" 2>/dev/null | grep -q '#[0-9]*:'"]
+        onExited: (exitCode, exitStatus) => {
+            fingerprint.available = exitCode === 0;
+            if (fingerprint.available) {
+                fingerprint.setStatus(I18n.t("lock.status.fingerprint_prompt"));
+                fingerprint.start();
+            }
+        }
+    }
+
+    PamContext {
+        id: pamFingerprint
+        config: "fingerprint"
+        configDirectory: Quickshell.shellPath("lock/pam.d")
+
+        onResponseRequiredChanged: {
+            if (responseRequired) respond("");
+        }
+
+        onCompleted: (result) => {
+            if (!rootLock.locked || root.isUnlocking) return;
+            if (result === PamResult.Success) {
+                root.finishUnlock();
+                return;
+            }
+            if (result === PamResult.Error) {
+                if (message.toLowerCase().indexOf("timed out") !== -1) {
+                    fingerprintRetryTimer.restart();
+                    return;
+                }
+                fingerprint.errors++;
+                console.warn("Lock: fingerprint PAM error:", message);
+                if (fingerprint.errors < 5) fingerprintRetryTimer.restart();
+                return;
+            }
+            fingerprint.tries++;
+            if (fingerprint.tries < fingerprint.maxTries) {
+                fingerprint.setStatus(I18n.t("lock.status.fingerprint_retry", { "tries": fingerprint.tries, "max": fingerprint.maxTries }));
+                fingerprintRetryTimer.restart();
+            } else {
+                fingerprint.setStatus(I18n.t("lock.status.fingerprint_failed"));
+            }
+        }
+
+        onError: (error) => {
+            console.warn("Lock: fingerprint PAM failed to start:", PamError.toString(error));
+        }
+    }
+
+    Timer {
+        id: fingerprintRetryTimer
+        interval: 800
+        onTriggered: fingerprint.start()
     }
 
     Timer {
@@ -269,6 +375,8 @@ Scope {
             kbPollerRestartTimer.restart();
             if (rootLock.locked) {
                 pam.start();
+                fingerprint.reset();
+                fingerprint.start();
             }
         }
     }

--- a/src/quickshell/lock/pam.d/fingerprint
+++ b/src/quickshell/lock/pam.d/fingerprint
@@ -1,0 +1,3 @@
+#%PAM-1.0
+
+auth    required    pam_fprintd.so    max-tries=1    timeout=30


### PR DESCRIPTION
One feature: unlock the lock screen with an enrolled fingerprint (fprintd) while the PIN prompt keeps working exactly as before.

## What it does
- Adds a second `PamContext` (`pamFingerprint`) that runs on its own PAM stack shipped in the repo, `src/quickshell/lock/pam.d/fingerprint` (`pam_fprintd.so max-tries=1 timeout=30`), via `configDirectory: Quickshell.shellPath("lock/pam.d")`. PAM stacks are serialised, so fingerprint and password cannot share one conversation; running two contexts is what gdm does too. No installer or `/etc/pam.d` changes are needed, and NixOS users only need the module path in that one file.
- The existing password context is untouched and still uses the default `login` stack, so machines without a reader or without enrolled prints behave exactly as today.
- Availability is checked on every lock with `fprintd-list "$(id -un)"` (needs at least one enrolled print), asynchronously, so a reader with no prints never produces an endless retry loop.
- A failed match retries up to `lock.fingerprintTries` (default 3) and then leaves the PIN prompt alone; the 30 s timeout with nobody touching the sensor just restarts listening; real PAM errors (device busy, module missing) stop after 5 attempts and are logged. Success goes through the normal `finishUnlock()` path, so the unlock animation is unchanged.
- Status text uses `lockUI.statusText` only and never sets `lockUI.failed`, so a half typed PIN is not wiped by a bad fingerprint. New strings: `lock.status.fingerprint_prompt`, `fingerprint_retry` (with `{tries}/{max}`), `fingerprint_failed`. English only here; other languages are in a separate translations PR as the template asks.
- The fingerprint context is aborted on unlock and restarted after resume from suspend, and `completeUnlock()` now also aborts a still open password conversation so the next lock starts clean.
- New `lock` settings section (`fingerprint: true`, `fingerprintTries: 3`) in `config/serpantinum/settings.json` and `nix/settings-options.nix`, read through `Config.getSetting("lock", ...)`. A settings UI toggle is intentionally not included to keep this PR to one thing.
- Adds `isLocked()` to the `lock` IPC target next to `activate()`, handy for scripts (`serpantinum ipc call lock isLocked`).

## Tested
Arch, Hyprland 0.56, Quickshell 0.3.1, fprintd 1.94.5, pam 1.7.2, Synaptics reader, running this branch as my daily shell:
- lock: both conversations start, the shell log shows the fprint stack prompting "Place your finger on the fingerprint reader" while the login stack shows "Password:", a touch unlocks in a few seconds with the normal animation
- password unlock still works with the reader listening
- no enrolled prints: no fingerprint context is started, PIN prompt unchanged
- `lock.fingerprint: false`: same as above

Related: #223 by @AntonUniatitskyi explores the same split. I went a different way because #223 moves the password stack to `/etc/pam.d/quickshell` files that are not shipped or installed, which breaks PIN unlock on a stock machine, and its status updates go through `lockUI.failed`, which clears the input. Happy to rebase on either if you prefer one over the other.