### PR TITLE
i18n: fingerprint lock status translations

### DIFF
--- a/src/assets/languages/az.json
+++ b/src/assets/languages/az.json
@@ -653,7 +653,10 @@
       "locked": "Kilidlidir",
       "access_denied": "Giriş rədd edildi",
       "authenticating": "Kimlik doğrulanır...",
-      "enter_pin": "PIN daxil edin"
+      "enter_pin": "PIN daxil edin",
+      "fingerprint_prompt": "Barmaq izi sensoruna toxunun və ya PIN daxil edin",
+      "fingerprint_retry": "Barmaq izi tanınmadı ({tries}/{max}), yenidən cəhd edin",
+      "fingerprint_failed": "Həddindən çox barmaq izi cəhdi, PIN daxil edin"
     },
     "power": {
       "suspend": "Yuxu rejiminə keçir",

--- a/src/assets/languages/de.json
+++ b/src/assets/languages/de.json
@@ -703,7 +703,10 @@
       "locked": "Gesperrt",
       "access_denied": "Zugriff verweigert",
       "authenticating": "Authentifizierung läuft...",
-      "enter_pin": "PIN eingeben"
+      "enter_pin": "PIN eingeben",
+      "fingerprint_prompt": "Fingersensor berühren oder PIN eingeben",
+      "fingerprint_retry": "Fingerabdruck nicht erkannt ({tries}/{max}), erneut versuchen",
+      "fingerprint_failed": "Zu viele Fingerabdruckversuche, PIN eingeben"
     },
     "power": {
       "suspend": "Standby",

--- a/src/assets/languages/es.json
+++ b/src/assets/languages/es.json
@@ -703,7 +703,10 @@
       "locked": "Bloqueado",
       "access_denied": "Acceso denegado",
       "authenticating": "Autenticando...",
-      "enter_pin": "Introduce el PIN"
+      "enter_pin": "Introduce el PIN",
+      "fingerprint_prompt": "Toca el sensor de huellas o introduce el PIN",
+      "fingerprint_retry": "Huella no reconocida ({tries}/{max}), inténtalo de nuevo",
+      "fingerprint_failed": "Demasiados intentos de huella, introduce el PIN"
     },
     "power": {
       "suspend": "Suspender",

--- a/src/assets/languages/hy.json
+++ b/src/assets/languages/hy.json
@@ -659,7 +659,10 @@
       "locked": "Կողպված է",
       "access_denied": "Մուտքը մերժված է",
       "authenticating": "Նույնականացում...",
-      "enter_pin": "Մուտքագրեք PIN-ը"
+      "enter_pin": "Մուտքագրեք PIN-ը",
+      "fingerprint_prompt": "Հպեք մատնահետքի սենսորին կամ մուտքագրեք PIN-ը",
+      "fingerprint_retry": "Մատնահետքը չի ճանաչվել ({tries}/{max}), փորձեք նորից",
+      "fingerprint_failed": "Չափազանց շատ մատնահետքի փորձեր, մուտքագրեք PIN-ը"
     },
     "power": {
       "suspend": "Քնեցնել",

--- a/src/assets/languages/it.json
+++ b/src/assets/languages/it.json
@@ -658,7 +658,10 @@
       "locked": "Bloccato",
       "access_denied": "Accesso negato",
       "authenticating": "Autenticazione...",
-      "enter_pin": "Inserisci il PIN"
+      "enter_pin": "Inserisci il PIN",
+      "fingerprint_prompt": "Tocca il sensore di impronte o inserisci il PIN",
+      "fingerprint_retry": "Impronta non riconosciuta ({tries}/{max}), riprova",
+      "fingerprint_failed": "Troppi tentativi con l'impronta, inserisci il PIN"
     },
     "power": {
       "suspend": "Sospendi",

--- a/src/assets/languages/ko.json
+++ b/src/assets/languages/ko.json
@@ -659,7 +659,10 @@
       "locked": "잠김",
       "access_denied": "접근이 거부되었습니다",
       "authenticating": "인증 중...",
-      "enter_pin": "PIN 입력"
+      "enter_pin": "PIN 입력",
+      "fingerprint_prompt": "지문 센서를 터치하거나 PIN을 입력하세요",
+      "fingerprint_retry": "지문을 인식하지 못했습니다 ({tries}/{max}), 다시 시도하세요",
+      "fingerprint_failed": "지문 시도 횟수 초과, PIN을 입력하세요"
     },
     "power": {
       "suspend": "절전",

--- a/src/assets/languages/pt.json
+++ b/src/assets/languages/pt.json
@@ -659,7 +659,10 @@
       "locked": "Bloqueado",
       "access_denied": "Acesso negado",
       "authenticating": "Autenticando...",
-      "enter_pin": "Digite o PIN"
+      "enter_pin": "Digite o PIN",
+      "fingerprint_prompt": "Toque no sensor de impressão digital ou digite o PIN",
+      "fingerprint_retry": "Impressão digital não reconhecida ({tries}/{max}), tente novamente",
+      "fingerprint_failed": "Muitas tentativas de impressão digital, digite o PIN"
     },
     "power": {
       "suspend": "Suspender",

--- a/src/assets/languages/ru.json
+++ b/src/assets/languages/ru.json
@@ -703,7 +703,10 @@
       "locked": "Заблокировано",
       "access_denied": "Отказано в доступе",
       "authenticating": "Аутентификация...",
-      "enter_pin": "Введите PIN"
+      "enter_pin": "Введите PIN",
+      "fingerprint_prompt": "Приложите палец к сканеру или введите PIN",
+      "fingerprint_retry": "Отпечаток не распознан ({tries}/{max}), попробуйте снова",
+      "fingerprint_failed": "Слишком много попыток, введите PIN"
     },
     "power": {
       "suspend": "Сон",

--- a/src/assets/languages/vi.json
+++ b/src/assets/languages/vi.json
@@ -659,7 +659,10 @@
       "locked": "Đã khóa",
       "access_denied": "Truy cập bị từ chối",
       "authenticating": "Đang xác thực...",
-      "enter_pin": "Nhập mã PIN"
+      "enter_pin": "Nhập mã PIN",
+      "fingerprint_prompt": "Chạm vào cảm biến vân tay hoặc nhập mã PIN",
+      "fingerprint_retry": "Không nhận dạng được vân tay ({tries}/{max}), thử lại",
+      "fingerprint_failed": "Quá nhiều lần thử vân tay, hãy nhập mã PIN"
     },
     "power": {
       "suspend": "Ngủ",


### PR DESCRIPTION
Translations only. Adds `lock.status.fingerprint_prompt`, `fingerprint_retry` and `fingerprint_failed` to az, de, es, hy, it, ko, pt, ru and vi, matching the English strings introduced in #284. Without that PR the keys are simply unused, so this can merge in either order.